### PR TITLE
Constrain batch size value in UI to avoid invalid values

### DIFF
--- a/modules/training_module.py
+++ b/modules/training_module.py
@@ -21,6 +21,8 @@ diffaug_pipes = ['color,translation,cutout', 'color,translation', 'color,cutout'
                  'translation', 'cutout,translation', 'cutout']
 configs = ['auto', 'stylegan2', 'paper256', 'paper512', 'paper1024', 'cifar']
 resize_mode = ['stretch','center crop']
+MBSTD_GROUP = 2
+BATCH_SIZE_CHOICES = [MBSTD_GROUP * x for x in range(1, 33)]
 
 class TrainingModule:
     def __init__(self, menu):
@@ -39,7 +41,9 @@ class TrainingModule:
         self.ada_pipe = 7
         self.diffaug_pipe = 0
         self.batch_size = 8
-        
+        if self.batch_size not in BATCH_SIZE_CHOICES:
+            self.batch_size = min(BATCH_SIZE_CHOICES, key=lambda x: abs(x - self.batch_size))
+
         # Native browsers for main training paths
         self.data_path_browser = NativeBrowserWidget()
         self.save_path_browser = NativeBrowserWidget()
@@ -392,10 +396,22 @@ class TrainingModule:
 
             imgui.text("Batch Size")
             imgui.same_line()
-            _, self.batch_size = imgui.input_int("##Batch Size", self.batch_size)
-            if self.batch_size < 1:
-                self.batch_size = 1
-            
+            input_width = int(self.menu.app.font_size * 6)
+            button_width = self.menu.app.font_size * 1.2
+            with imgui_utils.item_width(input_width):
+                imgui.input_text("##Batch Size", str(self.batch_size), 32, flags=imgui.INPUT_TEXT_READ_ONLY)
+            imgui.same_line()
+            if self.batch_size not in BATCH_SIZE_CHOICES:
+                self.batch_size = min(BATCH_SIZE_CHOICES, key=lambda x: abs(x - self.batch_size))
+            batch_idx = BATCH_SIZE_CHOICES.index(self.batch_size)
+            if imgui.button("-##batch_size", width=button_width):
+                batch_idx = max(0, batch_idx - 1)
+                self.batch_size = BATCH_SIZE_CHOICES[batch_idx]
+            imgui.same_line()
+            if imgui.button("+##batch_size", width=button_width):
+                batch_idx = min(len(BATCH_SIZE_CHOICES) - 1, batch_idx + 1)
+                self.batch_size = BATCH_SIZE_CHOICES[batch_idx]
+
             imgui.text("Configuration")
             imgui.same_line()
             _, self.config = imgui.combo("##Configuration", self.config, configs)
@@ -475,7 +491,7 @@ class TrainingModule:
                     glr=self.glr,
                     dlr=self.dlr,
                     map_depth=8,
-                    mbstd_group=2,
+                    mbstd_group=MBSTD_GROUP,
                     initstrength=None,
                     projected=False,
                     diffaugment= diffaug_pipes[self.diffaug_pipe] if self.aug == 1 else None,


### PR DESCRIPTION
Currently the batch size input is a free text input which allow for entering invalid values such as 0 or 1.

Technically batch size must be a multiple of the `mbstd_group` parameter which is currently hardcoded to `2`.

This change constraints the UI so that batch size can be incremented only with valid values using the -/+ buttons as mutliples of the `MBSTD_GROUP` constant.

Fixes #9 