### PR TITLE
Add energy usage and carbon emission tracking for training runs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
 
-click==8.1.7
+click>=8.1.8
 fbpca==1.0
 ffmpeg-python==0.2.0
 ffmpeg-downloader==0.4.1
@@ -22,13 +22,14 @@ opencv-python==4.8.1.78
 opensimplex==0.4.5
 pandas==2.1.1
 pillow==9.3.0
-psutil==5.9.6
+codecarbon>=3.2.3
+psutil>=6.0.0
 pyaudio==0.2.13
 pyinstaller==6.16.0
 pyopengl==3.1.7
 pyspng==0.1.3
 python-osc==1.8.3
-pyyaml==6.0.1
+pyyaml>=6.0.2
 requests>=2.30
 scikit-image==0.22.0
 scikit-learn==1.3.1

--- a/training/training_loop.py
+++ b/training/training_loop.py
@@ -24,6 +24,7 @@ from torch_utils.ops import conv2d_gradfix, grid_sample_gradfix
 from queue import Empty
 
 from metrics import metric_main
+from codecarbon import EmissionsTracker
 
 #----------------------------------------------------------------------------
 
@@ -315,6 +316,19 @@ def training_loop(
         except ImportError as err:
             print('Skipping tfevents export:', err)
 
+    # Initialize emissions tracker.
+    tracker = None
+    if rank == 0:
+        tracker = EmissionsTracker(
+            output_dir=run_dir,
+            output_file="emissions.csv",
+            save_to_api=False,
+            log_level="warning",
+            tracking_mode="process",
+            project_name="autolume",
+        )
+        tracker.start()
+
     # Train.
     if rank == 0:
         print(f'Training for {total_kimg} kimg...')
@@ -327,6 +341,8 @@ def training_loop(
     batch_idx = 0
     if progress_fn is not None:
         progress_fn(0, total_kimg)
+    prev_energy_wh = 0
+    prev_co2_g = 0
     while True:
         # Fetch training data.
         with torch.autograd.profiler.record_function('data_fetch'):
@@ -424,6 +440,19 @@ def training_loop(
         fields += [f"augment {training_stats.report0('Progress/augment', float(augment_pipe.p.cpu()) if augment_pipe is not None else 0):.3f}"]
         training_stats.report0('Timing/total_hours', (tick_end_time - start_time) / (60 * 60))
         training_stats.report0('Timing/total_days', (tick_end_time - start_time) / (24 * 60 * 60))
+        if rank == 0 and tracker is not None:
+            energy_wh = tracker._total_energy.kWh * 1000
+            co2_g = tracker._total_emissions * 1000
+            energy_tick = energy_wh - prev_energy_wh
+            co2_tick = co2_g - prev_co2_g
+            prev_energy_wh = energy_wh
+            prev_co2_g = co2_g
+            fields += [f"energy {energy_tick:.4f} Wh"]
+            fields += [f"co2 {co2_tick:.4f} g"]
+            training_stats.report0('Emissions/energy_wh', energy_wh)
+            training_stats.report0('Emissions/energy_wh_per_tick', energy_tick)
+            training_stats.report0('Emissions/co2eq_g', co2_g)
+            training_stats.report0('Emissions/co2eq_g_per_tick', co2_tick)
         if rank == 0:
             print(' '.join(fields))
             reply.put([' '.join(fields), False])
@@ -494,6 +523,8 @@ def training_loop(
                 value = phase.start_event.elapsed_time(phase.end_event)
             training_stats.report0('Timing/' + phase.name, value)
         stats_collector.update()
+        if rank == 0 and tracker is not None:
+            tracker.flush()
         stats_dict = stats_collector.as_dict()
 
         # Update logs.
@@ -524,6 +555,9 @@ def training_loop(
     # Done.
     if rank == 0:
         print()
+        if tracker is not None:
+            emissions = tracker.stop()
+            print(f'Total emissions: {emissions * 1000:.4f} g CO2eq')
         print('Exiting...')
 
 #----------------------------------------------------------------------------


### PR DESCRIPTION
This change integrates CodeCarbon for tracking energy usage and carbon emission estimates and other resource usage equivalencies. See https://codecarbon.io/

Metrics are displayed and computed at every training iteration (ticks) and the complete emission logs are dumped into the training run folder as `emissions.csv`. Units are displayed in Wh for energy usage and gCO2eq for emissions.

<img width="1962" height="314" alt="Screenshot 2026-03-14 at 14 16 38" src="https://github.com/user-attachments/assets/341b3bc0-b955-4710-9ae8-b1063b8339f2" />