### PR TITLE
Fix OSC mapping and preset loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,6 @@ models/
 recordings/
 training-runs/
 data/
+presets/
+torch_extensions/
 *.pth

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ bin/
 models/
 recordings/
 training-runs/
+ganspace-features/
 data/
 presets/
 torch_extensions/

--- a/widgets/adjuster_widget.py
+++ b/widgets/adjuster_widget.py
@@ -44,13 +44,14 @@ class AdjusterWidget:
         self.dirs, self.paths, self.all_dir, self.weights, self.vslide_use_osc, new_addresses, self.vslide_mappings = params
         for i,old_address in enumerate(self.vslide_address):
             try:
-                self.viz.osc_dispatcher.unmap(old_address,
+                self.viz.osc_dispatcher.unmap(f"/{old_address}",
                                                 self.vec_handler(i))
             except:
                 print(f"{old_address} is not mapped")
         for i, new_address in enumerate(new_addresses):
-            self.viz.osc_dispatcher.map(new_address,
-                                          self.vec_handler(i))
+            if self.vslide_use_osc[i] and new_address and new_address != "...":
+                self.viz.osc_dispatcher.map(f"/{new_address}",
+                                              self.vec_handler(i))
         self.vslide_address = new_addresses
         self.file_dialogs = [BrowseWidget(self.viz, f"Vector##vec{i}", os.path.abspath(os.getcwd()), ["*",".pth", ".pt"], width=self.viz.app.button_w, multiple=False, traverse_folders=False) for i in range(len(self.weights))]
 
@@ -140,7 +141,7 @@ class AdjusterWidget:
                         self.viz.osc_dispatcher.map(f"/{new_address}",
                                                       self.vec_handler(i))
                         try:
-                            self.viz.osc_dispatcher.unmap(self.vslide_address[i],
+                            self.viz.osc_dispatcher.unmap(f"/{self.vslide_address[i]}",
                                                             self.vec_handler(i))
                         except:
                             print(f"{self.vslide_address[i]} is not mapped")

--- a/widgets/collapsable_layer.py
+++ b/widgets/collapsable_layer.py
@@ -156,8 +156,9 @@ class LayerWidget:
         self.cached_transforms = cached_transforms
         for i, trans in enumerate(self.cached_transforms):
             for j in range(len(trans.params)):
-                self.viz.osc_dispatcher.map(f"/{trans.osc_address[j]}",
-                                            self.transform_osc(trans, param_idx=j))
+                if trans.use_osc and trans.osc_address[j]:
+                    self.viz.osc_dispatcher.map(f"/{trans.osc_address[j]}",
+                                                self.transform_osc(trans, param_idx=j))
 
         for _, noise in self.noises.items():
             try:
@@ -168,7 +169,8 @@ class LayerWidget:
                 print(f"{noise['osc_address']} is not mapped")
         self.noises = noises
         for _, noise in self.noises.items():
-            self.viz.osc_dispatcher.map(f"/{noise['osc_address']}", self.noise_osc(noise))
+            if noise["use_osc"] and noise["osc_address"]:
+                self.viz.osc_dispatcher.map(f"/{noise['osc_address']}", self.noise_osc(noise))
 
     def save(self, path):
         with open(path, "wb") as f:

--- a/widgets/latent_widget.py
+++ b/widgets/latent_widget.py
@@ -253,17 +253,36 @@ class LatentWidget:
     def model_handler(self):
         def func(address, *args):
             try:
-                assert (type(args[-1]) is str), f"OSC Message and Parameter type must align [OSC] {type(args[-1])} != [Param] {str}"
-                # check if the string that is sent in the message os.exists
-                print(os.getcwd() + os.sep + 'models' + os.sep + args[-1])
-                if os.path.exists(args[-1]):
-                    print(os.getcwd() + os.sep + 'models' + os.sep + args[-1])
-                    self.viz.pickle_widget.user_pkl = args[-1]
-                    self.viz.pickle_widget.load_pkl(args[-1])
-                elif os.path.exists(os.getcwd() + os.sep + 'models' + os.sep + args[-1]):
-                    print(os.getcwd() + os.sep + 'models' + os.sep + args[-1])
-                    self.viz.pickle_widget.user_pkl = os.getcwd() + os.sep + 'models' + os.sep + args[-1]
-                    self.viz.pickle_widget.load_pkl(os.getcwd() + os.sep + 'models' + os.sep + args[-1])
+                pickle_widget = self.viz.pickle_widget
+                value = args[-1]
+
+                if isinstance(value, (int, float)):
+                    index = round(value)
+                    if index < 0 or index >= len(pickle_widget.browse_cache):
+                        print(f"OSC model: index {index} out of range (0-{len(pickle_widget.browse_cache) - 1})")
+                        return
+                    target = pickle_widget.browse_cache[index]
+                elif isinstance(value, str):
+                    if os.path.exists(value):
+                        target = value
+                    elif os.path.exists(os.path.join(os.getcwd(), 'models', value)):
+                        target = os.path.join(os.getcwd(), 'models', value)
+                    else:
+                        target = None
+                        for path in pickle_widget.browse_cache:
+                            if value in os.path.basename(path):
+                                target = path
+                                break
+                    if target is None:
+                        print(f"OSC model: no model matching '{value}' found")
+                        return
+                else:
+                    return
+
+                if target == pickle_widget.cur_pkl:
+                    return
+
+                pickle_widget.load_pkl(target, ignore_errors=True)
             except Exception as e:
                 self.viz.print_error(e)
         return func

--- a/widgets/layer_widget.py
+++ b/widgets/layer_widget.py
@@ -85,7 +85,7 @@ class LayerWidget:
         for i, trans in enumerate(self.cached_transforms):
             for j in range(len(trans.params)):
                 try:
-                    self.viz.osc_dispatcher.unmap(trans.osc_address[j],
+                    self.viz.osc_dispatcher.unmap(f"/{trans.osc_address[j]}",
                                                   self.transform_osc(trans, param_idx=j))
                 except Exception as e:
                     print(e)
@@ -94,19 +94,21 @@ class LayerWidget:
         self.cached_transforms = cached_transforms
         for i, trans in enumerate(self.cached_transforms):
             for j in range(len(trans.params)):
-                self.viz.osc_dispatcher.map(trans.osc_address[j],
-                                            self.transform_osc(trans, param_idx=j))
+                if trans.use_osc and trans.osc_address[j]:
+                    self.viz.osc_dispatcher.map(f"/{trans.osc_address[j]}",
+                                                self.transform_osc(trans, param_idx=j))
 
         for _, noise in self.noises.items():
             try:
-                self.viz.osc_dispatcher.unmap(noise["osc_address"],
+                self.viz.osc_dispatcher.unmap(f"/{noise['osc_address']}",
                                               self.noise_osc(noise))
             except Exception as e:
                 print(e)
                 print(f"{noise['osc_address']} is not mapped")
         self.noises = noises
         for _, noise in self.noises.items():
-            self.viz.osc_dispatcher.map(noise["osc_address"], self.noise_osc(noise))
+            if noise["use_osc"] and noise["osc_address"]:
+                self.viz.osc_dispatcher.map(f"/{noise['osc_address']}", self.noise_osc(noise))
 
     def save(self, path):
         with open(path, "wb") as f:
@@ -388,7 +390,7 @@ class LayerWidget:
 
                                         if changed:
                                             try:
-                                                self.viz.osc_dispatcher.unmap(trans.osc_address[j],
+                                                self.viz.osc_dispatcher.unmap(f"/{trans.osc_address[j]}",
                                                                               self.osc_funcs[trans.imgui_id][j])
                                                 print(f"Unmapped",trans.osc_address[j])
                                                 print(self.viz.osc_dispatcher.mappings)
@@ -396,7 +398,7 @@ class LayerWidget:
                                                 print(f"{trans.osc_address[j]} is not mapped")
                                                 print(e)
                                                 print(self.viz.osc_dispatcher._map)
-                                            self.viz.osc_dispatcher.map(address,
+                                            self.viz.osc_dispatcher.map(f"/{address}",
                                                                         self.osc_funcs[trans.imgui_id][j])
                                             trans.osc_address[j] = address
                                     # for j in range(len(trans.params)):
@@ -497,11 +499,11 @@ class LayerWidget:
                         if changed:
 
                             try:
-                                self.viz.osc_dispatcher.unmap(noise["osc_address"],
+                                self.viz.osc_dispatcher.unmap(f"/{noise['osc_address']}",
                                                               self.noise_osc(noise))
                             except:
                                 print(f"{noise['osc_address']} is not mapped")
-                            self.viz.osc_dispatcher.map(address,
+                            self.viz.osc_dispatcher.map(f"/{address}",
                                                         self.noise_osc(noise))
                             noise["osc_address"] = address
 

--- a/widgets/osc_menu.py
+++ b/widgets/osc_menu.py
@@ -35,12 +35,14 @@ class OscMenu:
         return self.use_map, self.use_osc, self.osc_addresses, self.cached_osc_addresses, self.mappings
 
     def set_params(self, params):
-        # TODO unmap old addresses
         self.use_map, self.use_osc, self.osc_addresses, self.cached_osc_addresses, self.mappings = params
-        for key, func in self.funcs.items():  # maybe with map faster
+        for key, func in self.funcs.items():
             self.funcs[key] = self.check_osc(func, key)
         for key, func in self.funcs.items():
             self.wrapped_funcs[key] = self.map_func(self.funcs[key], key)
+        for key in self.funcs.keys():
+            if self.use_osc.get(key, False) and self.osc_addresses[key] != "...":
+                self.viz.osc_dispatcher.map(f"/{self.osc_addresses[key]}", self.wrapped_funcs[key])
 
     def check_osc(self, func, key):
         def wrapper(*args, **kwargs):

--- a/widgets/trunc_noise_widget.py
+++ b/widgets/trunc_noise_widget.py
@@ -22,7 +22,7 @@ except ModuleNotFoundError:
 class TruncationNoiseWidget:
     def __init__(self, viz):
         self.viz            = viz
-        self.params = dnnlib.EasyDict(trunc_psi=0.8, global_noise=1, noise_enable=True, noise_seed=0, noise_anim=False, reset=False)
+        self.params = dnnlib.EasyDict(trunc_psi=0.8, global_noise=1.0, noise_enable=True, noise_seed=0, noise_anim=False, reset=False)
         self.prev_num_ws    = 0
 
         funcs = dict(zip(["Diversity", "Global Noise", "Noise On/Off", "Noise Seed", "Animate Noise", "Reset"], [self.osc_handler(param) for param in
@@ -35,7 +35,6 @@ class TruncationNoiseWidget:
         def func(address, *args):
             try:
                 nec_type = type(self.params[param])
-                print(self.params)
                 self.params[param] = nec_type(args[-1])
             except Exception as e:
                 print(e)
@@ -46,6 +45,8 @@ class TruncationNoiseWidget:
 
     def set_params(self, params):
         self.params, self.osc_params = params
+        self.params.global_noise = float(self.params.global_noise)
+        self.params.trunc_psi = float(self.params.trunc_psi)
         self.osc_menu.set_params(self.osc_params)
 
     def save(self, path):
@@ -93,7 +94,7 @@ class TruncationNoiseWidget:
                     self.params.noise_enable = True
                     self.params.noise_seed = 0
                     self.params.noise_anim = False
-                    self.params.global_noise = 1
+                    self.params.global_noise = 1.0
                     self.params.reset = False
 
             self.osc_menu()


### PR DESCRIPTION
This change fixes the following bugs:
- OSC mapping not being properly activated on initial preset loading
- OSC values mapping to noise were rounded as int, causing jumps when controlling noise

This change enhances the current model mapping from OSC, model can now be provided as:
- Full path to model
- Partial name
- Index in the model list