### PR TITLE
Fix: inconsistencies in path object type

### DIFF
--- a/modules/pca_module.py
+++ b/modules/pca_module.py
@@ -29,7 +29,7 @@ class PCA_Module:
         self.help_icon = HelpIconWidget()
         self.help_texts, self.help_urls = self.help_icon.load_help_texts("pca")
         cwd = os.getcwd()
-        self.save_path = os.path.join(cwd,"ganspace_features").replace('\\', '/')
+        self.save_path = os.path.join(cwd,"ganspace_features")
 
         self.menu = menu
         self.app = menu.app

--- a/modules/preprocessing_module.py
+++ b/modules/preprocessing_module.py
@@ -80,7 +80,7 @@ class DataPreprocessing:
         self.progress_file = ""
         self.processing_completed = False
         
-        self.save_path = self.settings.output_path 
+        self.save_path = str(self.settings.output_path) 
 
         self.help_icon = HelpIconWidget()
         self.help_texts, self.help_urls = self.help_icon.load_help_texts("preprocessing")
@@ -486,7 +486,7 @@ class DataPreprocessing:
         imgui.text("Save Path")
         self.help_icon.render(self.help_texts.get("save_path"))
         
-        _, new_save_path = imgui_utils.input_text("##save_path", self.save_path, 1024, 0, 
+        _, new_save_path = imgui_utils.input_text("##save_path", str(self.save_path), 1024, 0, 
         width=parameter_column_width - imgui.calc_text_size("Browse##save_path")[0] + 8)
         if new_save_path != self.save_path:
             self.save_path = new_save_path.replace('\\', '/')
@@ -1069,7 +1069,7 @@ class DataPreprocessing:
         """Construct output path from parent directory + folder name + resolution"""
         resolution_suffix = f"_{self.settings.size}x{self.settings.size}"
         folder_name_with_resolution = self.settings.folder_name + resolution_suffix
-        return (Path(self.save_path) / folder_name_with_resolution).as_posix()
+        return str(Path(self.save_path) / folder_name_with_resolution)
     
     def process_dataset(self):
         """Start the dataset processing in a separate process"""

--- a/modules/training_module.py
+++ b/modules/training_module.py
@@ -471,7 +471,7 @@ class TrainingModule:
 
                 kwargs = dnnlib.EasyDict(
                     outdir=self.save_path,
-                    data=target_data_path,
+                    data=str(target_data_path),
                     cfg=configs[self.config],
                     batch=self.batch_size,
                     topk=None,

--- a/modules/training_module.py
+++ b/modules/training_module.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from re import S
 import zipfile
 
 import imgui
@@ -28,8 +29,8 @@ BATCH_SIZE_CHOICES = [MBSTD_GROUP * x for x in range(1, 33)]
 class TrainingModule:
     def __init__(self, menu):
         cwd = Path.cwd()
-        self.save_path = (cwd / "training-runs").as_posix()
-        self.data_path = (cwd / "data").as_posix()
+        self.save_path = str(cwd / "training-runs")
+        self.data_path = str(cwd / "data")
         # create data folder if not exists
         data_dir = (cwd / "data").resolve()
         if not data_dir.exists():
@@ -87,9 +88,9 @@ class TrainingModule:
                 
         self.preprocessing_data_browser = NativeBrowserWidget()
         self.preprocessing_save_browser = NativeBrowserWidget()
-        self.preprocessing_save_path = self.preprocessing_settings_obj.output_path  
+        self.preprocessing_save_path = str(self.preprocessing_settings_obj.output_path)  
         self.preprocessing_folder_name = self.preprocessing_settings_obj.folder_name  
-        self.preprocessing_data_path = (Path.home() / "Desktop").as_posix()
+        self.preprocessing_data_path = str(Path.home() / "Desktop")
         self.data_path_has_videos = False  
         self.video_files_list = [] 
         
@@ -356,8 +357,8 @@ class TrainingModule:
                             if pkl_path.is_file():
                                 pkl_path_str = str(pkl_path)
                                 pkl_files.append(pkl_path_str)
-                                if pkl_path not in self.browse_cache:
-                                    self.browse_cache.append(pkl_path)
+                                if pkl_path_str not in self.browse_cache:
+                                    self.browse_cache.append(pkl_path_str)
                     
                     if pkl_files:
                         print(f"Found {len(pkl_files)} PKL files in directory:")
@@ -804,7 +805,7 @@ class TrainingModule:
         # Add resolution suffix to folder name and construct full path
         resolution_suffix = f"_{self.img_size}x{self.img_size}"
         folder_name_with_resolution = self.preprocessing_folder_name + resolution_suffix
-        self.dataset_output_path = (Path(self.preprocessing_save_path) / folder_name_with_resolution)
+        self.dataset_output_path = str(Path(self.preprocessing_save_path) / folder_name_with_resolution)
         
         self.temp_image_files = list(image_files)
         self.extracted_frame_directories = []

--- a/utils/dataset_preprocessing_utils.py
+++ b/utils/dataset_preprocessing_utils.py
@@ -26,7 +26,7 @@ class DatasetPreprocessingUtils:
             "yFlip": False
         }
         self.folder_name = "training_dataset"
-        self.output_path = str(Path.cwd() / "data").replace('\\', '/')
+        self.output_path = Path.cwd() / "data"
 
 
     def load_images(self, image_path):

--- a/widgets/help_icon_widget.py
+++ b/widgets/help_icon_widget.py
@@ -55,7 +55,7 @@ class HelpIconWidget:
         """Load the help icon image as a texture"""
         try:
             if Path(self.icon_path).exists():
-                help_img = cv2.imread(Path(self.icon_path).as_posix(), cv2.IMREAD_UNCHANGED)
+                help_img = cv2.imread(str(Path(self.icon_path).as_posix()), cv2.IMREAD_UNCHANGED)
                 if help_img is not None:
                     self.help_icon_texture = gl_utils.Texture(
                         image=help_img,


### PR DESCRIPTION
Fix save path and data path in Preprocessing and Training Module which previously caused app to crash due to imgui requiring str object as input.

Previous crash:
1. Preprocessing module / quick settings
2. Preprocess data, but same folder name exists in the output path
3. Autolume crash due to duplicate path handling (imgui path input)