### PR TITLE
perf: implement caching to thumbnail render

### DIFF
--- a/modules/preprocessing_module.py
+++ b/modules/preprocessing_module.py
@@ -22,8 +22,8 @@ class DataPreprocessing:
         self.settings = DatasetPreprocessingUtils()
 
         self.data_browser = NativeBrowserWidget()
-        self.thumbnail_widget = ThumbnailWidget() # Imported image thumbnails
-        self.video_thumbnail_widget = ThumbnailWidget()  # Video popup thumbnails
+        self.thumbnail_widget = ThumbnailWidget(padding_value=26)  # Imported image thumbnails
+        self.video_thumbnail_widget = ThumbnailWidget()  # Video popup thumbnails (black padding)
         self.image_preview_widget = ImagePreviewWidget()
         self.loading_widget = LoadingOverlayManager(app)  # Enhanced loading overlay manager
 
@@ -177,7 +177,6 @@ class DataPreprocessing:
                     delattr(self, 'last_fps')
                 if hasattr(self, 'last_expected_frames'):
                     delattr(self, 'last_expected_frames')
-                self.video_thumbnail_widget.set_render_mode(True)
                 imgui.open_popup("Video Frame Extraction")
 
         # Video Frame Extraction Popup
@@ -275,7 +274,6 @@ class DataPreprocessing:
 
             if imgui_utils.button("Back to Main Menu", width=left_popup_width - 10, enabled=True):
                 self.selected_video_files = []
-                self.video_thumbnail_widget.set_render_mode(False)
                 # Reset cache variables when closing popup
                 if hasattr(self, 'last_video_count'):
                     delattr(self, 'last_video_count')
@@ -667,21 +665,10 @@ class DataPreprocessing:
         imgui.same_line()
         imgui.text(f"({len(self.imported_files)} images)")
         
-        imgui.same_line(position=imgui.get_window_width() - imgui.calc_text_size("Render Thumbnail")[0] - imgui.calc_text_size("Select All")[0] - 70)
+        imgui.same_line(position=imgui.get_window_width() - imgui.calc_text_size("Select All")[0] - 50)
 
-        prev_thumbnail_mode = self.thumbnail_widget.generate_thumbnails
-        generate_thumbnails_clicked, self.thumbnail_widget.generate_thumbnails = imgui.checkbox(
-            "Render Thumbnail", self.thumbnail_widget.generate_thumbnails
-        )
-
-        imgui.same_line()
-        
         if imgui.button("Select All"):
             self.thumbnail_widget.select_all()
-        
-        if generate_thumbnails_clicked:
-            new_thumbnail_mode = self.thumbnail_widget.generate_thumbnails
-            self.thumbnail_widget.set_thumbnail_mode(new_thumbnail_mode, prev_thumbnail_mode)
 
         imgui.separator()
 

--- a/modules/preprocessing_module.py
+++ b/modules/preprocessing_module.py
@@ -667,7 +667,7 @@ class DataPreprocessing:
         
         imgui.same_line(position=imgui.get_window_width() - imgui.calc_text_size("Select All")[0] - 50)
 
-        if imgui.button("Select All"):
+        if imgui.button("Select All", width=self.app.button_w):
             self.thumbnail_widget.select_all()
 
         imgui.separator()
@@ -685,7 +685,7 @@ class DataPreprocessing:
 
         self.thumbnail_widget.poll()
 
-        remove_selected = imgui.button("Remove Selected Images", width=available_width, height=30)
+        remove_selected = imgui.button("Remove Selected Images", width=available_width + 18, height=30)
         remove_selected = remove_selected or self.thumbnail_widget.is_delete_pressed()
         
         if remove_selected:
@@ -710,7 +710,7 @@ class DataPreprocessing:
         
         imgui.text("Image Preview")
 
-        imgui.same_line(position=imgui.get_window_width() - imgui.calc_text_size("Preview Original")[0] - 50)
+        imgui.same_line(position=imgui.get_window_width() - imgui.calc_text_size("Preview Original")[0] - 55)
         # Preview Original button
         preview_original_clicked, preview_original_new = imgui.checkbox("Preview Original", self.preview_original)
         if preview_original_clicked:

--- a/modules/preprocessing_module.py
+++ b/modules/preprocessing_module.py
@@ -24,23 +24,8 @@ class DataPreprocessing:
         self.data_browser = NativeBrowserWidget()
         self.thumbnail_widget = ThumbnailWidget() # Imported image thumbnails
         self.video_thumbnail_widget = ThumbnailWidget()  # Video popup thumbnails
-        self.video_thumbnail_widget.generate_thumbnails = True  # Always render video thumbnails
         self.image_preview_widget = ImagePreviewWidget()
         self.loading_widget = LoadingOverlayManager(app)  # Enhanced loading overlay manager
-        
-        # Background thumbnail processing
-        self.thumbnail_queue = mp.Queue()
-        self.thumbnail_reply = mp.Queue()
-        self.thumbnail_process = None
-        self.is_processing_thumbnails = False
-        self.thumbnail_process_started = False
-        self._requested_thumbnail_paths = set()
-        
-        # Video thumbnail processing
-        self.video_thumbnail_queue = mp.Queue()
-        self.video_thumbnail_reply = mp.Queue()
-        self.video_thumbnail_process = None
-        self.is_processing_video_thumbnails = False 
 
         self.imported_files = [] 
         self.selected_video_files = [] 
@@ -141,10 +126,6 @@ class DataPreprocessing:
             else:
                 self.imported_files.extend(selected_images)
                 self.thumbnail_widget.update_thumbnails(self.imported_files)
-                
-                if self.thumbnail_widget.generate_thumbnails and self.imported_files:
-                    self._start_background_thumbnail_generation()
-                
                 self.last_selected_file = None
 
         imgui.set_next_window_size(self.app.content_width // 2.5, self.app.content_height // 2.5, imgui.ONCE)
@@ -196,8 +177,7 @@ class DataPreprocessing:
                     delattr(self, 'last_fps')
                 if hasattr(self, 'last_expected_frames'):
                     delattr(self, 'last_expected_frames')
-                # Start background thumbnail generation for video thumbnails
-                self._start_video_thumbnail_generation()
+                self.video_thumbnail_widget.set_render_mode(True)
                 imgui.open_popup("Video Frame Extraction")
 
         # Video Frame Extraction Popup
@@ -271,10 +251,7 @@ class DataPreprocessing:
                                 self.imported_files.extend(frame_files)
 
                             self.thumbnail_widget.update_thumbnails(self.imported_files)
-                            
-                            if self.thumbnail_widget.generate_thumbnails and self.imported_files:
-                                self._start_background_thumbnail_generation()
-                            
+
                             # Reset variables
                             self.selected_video_files = [] 
                             self.is_processing_video = False
@@ -297,8 +274,8 @@ class DataPreprocessing:
             imgui.spacing()
 
             if imgui_utils.button("Back to Main Menu", width=left_popup_width - 10, enabled=True):
-                self.selected_video_files = []  
-                self._stop_video_thumbnail_generation()
+                self.selected_video_files = []
+                self.video_thumbnail_widget.set_render_mode(False)
                 # Reset cache variables when closing popup
                 if hasattr(self, 'last_video_count'):
                     delattr(self, 'last_video_count')
@@ -329,8 +306,8 @@ class DataPreprocessing:
                     self.video_thumbnail_widget.update_thumbnails(self.selected_video_files)
                     self.last_video_count = len(self.selected_video_files)
 
-                self._check_video_thumbnail_results() 
-                
+                self.video_thumbnail_widget.poll()
+
                 self.video_thumbnail_widget.render_thumbnails(video_available_width, video_available_height)
             else:
                 imgui.text("No videos selected.")
@@ -705,10 +682,6 @@ class DataPreprocessing:
         if generate_thumbnails_clicked:
             new_thumbnail_mode = self.thumbnail_widget.generate_thumbnails
             self.thumbnail_widget.set_thumbnail_mode(new_thumbnail_mode, prev_thumbnail_mode)
-            if new_thumbnail_mode and self.imported_files:
-                self._start_background_thumbnail_generation()
-            else:
-                self._stop_background_thumbnail_generation()
 
         imgui.separator()
 
@@ -720,13 +693,10 @@ class DataPreprocessing:
         available_height = scroll_height
         self.thumbnail_widget.render_thumbnails(available_width, available_height)
 
-        imgui.end_child()  
+        imgui.end_child()
         # End Thumbnails Scroll
-        
-        self._check_background_thumbnail_results()
 
-        if self.thumbnail_widget.generate_thumbnails:
-            self._request_visible_thumbnails()
+        self.thumbnail_widget.poll()
 
         remove_selected = imgui.button("Remove Selected Images", width=available_width, height=30)
         remove_selected = remove_selected or self.thumbnail_widget.is_delete_pressed()
@@ -740,7 +710,6 @@ class DataPreprocessing:
 
             self.thumbnail_widget.update_thumbnails(self.imported_files)
             self.thumbnail_widget.clear_selected()
-            self._requested_thumbnail_paths = set()
             self.last_selected_file = None
 
         imgui.end() 
@@ -862,193 +831,9 @@ class DataPreprocessing:
             self.imported_files.extend(files_to_add)
         
         self.thumbnail_widget.update_thumbnails(self.imported_files)
-        
-        if self.thumbnail_widget.generate_thumbnails and self.imported_files:
-            self._start_background_thumbnail_generation()
-        
         self.last_selected_file = None
     # ------------------------------
 
-     # --- Background Thumbnail Generation Helper Functions ---
-    def _start_background_thumbnail_generation(self):
-        """Ensure the background thumbnail process is running. Actual file
-        requests are sent lazily each frame by _request_visible_thumbnails()."""
-        if not self.thumbnail_process_started or (self.thumbnail_process is not None and not self.thumbnail_process.is_alive()):
-            self.thumbnail_process = mp.Process(
-                target=ThumbnailWidget.process_thumbnails_background,
-                args=(self.thumbnail_queue, self.thumbnail_reply)
-            )
-            self.thumbnail_process.start()
-            self.thumbnail_process_started = True
-
-        self.is_processing_thumbnails = True
-        self._requested_thumbnail_paths = set()
-
-    def _request_visible_thumbnails(self):
-        """Send generation requests for visible files that haven't been requested yet."""
-        if not self.thumbnail_process_started:
-            return
-
-        pending = self.thumbnail_widget.get_pending_render_paths()
-        new_paths = [fp for fp in pending if fp not in self._requested_thumbnail_paths]
-        if not new_paths:
-            return
-
-        request = {
-            'type': 'generate_thumbnails',
-            'file_paths': new_paths,
-            'thumbnail_size': self.thumbnail_widget.thumbnail_size
-        }
-        self.thumbnail_queue.put(request)
-        self._requested_thumbnail_paths.update(new_paths)
-        self.is_processing_thumbnails = True
-    
-    def _start_video_thumbnail_generation(self):
-        """Start background thumbnail generation process for video thumbnails"""
-        if self.is_processing_video_thumbnails:
-            return  
-        
-        # Start process if not started or if it died
-        if self.video_thumbnail_process is None or not self.video_thumbnail_process.is_alive():
-            self.video_thumbnail_process = mp.Process(
-                target=ThumbnailWidget.process_thumbnails_background,
-                args=(self.video_thumbnail_queue, self.video_thumbnail_reply)
-            )
-            self.video_thumbnail_process.start()
-        
-        # Send thumbnail generation request
-        self.is_processing_video_thumbnails = True
-        
-        # Send request with file paths and thumbnail size
-        request = {
-            'type': 'generate_thumbnails',
-            'file_paths': self.selected_video_files,
-            'thumbnail_size': self.video_thumbnail_widget.thumbnail_size
-        }
-        self.video_thumbnail_queue.put(request)
-    
-    def _stop_background_thumbnail_generation(self):
-        """Stop background thumbnail generation process"""
-        if self.thumbnail_process is not None and self.thumbnail_process.is_alive():
-            try:
-                # Send shutdown signal
-                self.thumbnail_queue.put({'type': 'shutdown'})
-                
-                self.thumbnail_process.join(timeout=1.0)
-                
-                if self.thumbnail_process.is_alive():
-                    self.thumbnail_process.terminate()
-                    self.thumbnail_process.join(timeout=1.0)
-                    
-                    if self.thumbnail_process.is_alive():
-                        self.thumbnail_process.kill()
-                        self.thumbnail_process.join()
-                        
-            except Exception as e:
-                print(f"Error stopping thumbnail process: {e}")
-            finally:
-                self.thumbnail_process = None
-        
-        try:
-            while not self.thumbnail_queue.empty():
-                self.thumbnail_queue.get_nowait()
-        except:
-            pass
-            
-        try:
-            while not self.thumbnail_reply.empty():
-                self.thumbnail_reply.get_nowait()
-        except:
-            pass
-        
-        # Reset processing state
-        self.is_processing_thumbnails = False
-        self.thumbnail_process_started = False
-        self._requested_thumbnail_paths = set()
-    
-    def _check_background_thumbnail_results(self):
-        """Check for background thumbnail generation results"""
-        if not self.is_processing_thumbnails or self.thumbnail_reply.empty():
-            return
-        
-        try:
-            while not self.thumbnail_reply.empty():
-                result = self.thumbnail_reply.get_nowait()
-                
-                if result['type'] == 'thumbnail':
-                    file_path = result['file_path']
-                    thumbnail_data = result['thumbnail_data']
-                    self.thumbnail_widget.update_thumbnail_from_data(file_path, thumbnail_data)
-                    self._requested_thumbnail_paths.discard(file_path)
-                elif result['type'] == 'completed':
-                    if self.thumbnail_queue.empty():
-                        self.is_processing_thumbnails = False
-                    
-        except Exception as e:
-            print(f"Error processing background thumbnail results: {e}")
-    
-    def _check_video_thumbnail_results(self):
-        """Check for video thumbnail generation results"""
-        if not self.is_processing_video_thumbnails or self.video_thumbnail_reply.empty():
-            return
-        
-        try:
-            while not self.video_thumbnail_reply.empty():
-                result = self.video_thumbnail_reply.get_nowait()
-                
-                if result['type'] == 'thumbnail':
-                    # Update video thumbnail widget with processed data
-                    file_path = result['file_path']
-                    thumbnail_data = result['thumbnail_data']
-                    self.video_thumbnail_widget.update_thumbnail_from_data(file_path, thumbnail_data)
-                elif result['type'] == 'completed':
-                    self.is_processing_video_thumbnails = False
-                    
-        except Exception as e:
-            print(f"Error processing video thumbnail results: {e}")
-    
-    def _stop_video_thumbnail_generation(self):
-        """Stop background video thumbnail generation process"""
-        if self.video_thumbnail_process is not None and self.video_thumbnail_process.is_alive():
-            try:
-                # Send shutdown signal
-                self.video_thumbnail_queue.put({'type': 'shutdown'})
-                
-                # Wait for graceful shutdown
-                self.video_thumbnail_process.join(timeout=1.0)
-                
-                # Force terminate if still alive
-                if self.video_thumbnail_process.is_alive():
-                    self.video_thumbnail_process.terminate()
-                    self.video_thumbnail_process.join(timeout=1.0)
-                    
-                    # Kill if still alive
-                    if self.video_thumbnail_process.is_alive():
-                        self.video_thumbnail_process.kill()
-                        self.video_thumbnail_process.join()
-                        
-            except Exception as e:
-                print(f"Error stopping video thumbnail process: {e}")
-            finally:
-                self.video_thumbnail_process = None
-        
-        # Clear queues
-        try:
-            while not self.video_thumbnail_queue.empty():
-                self.video_thumbnail_queue.get_nowait()
-        except:
-            pass
-            
-        try:
-            while not self.video_thumbnail_reply.empty():
-                self.video_thumbnail_reply.get_nowait()
-        except:
-            pass
-        
-        # Reset processing state
-        self.is_processing_video_thumbnails = False
-    # ------------------------------
-    
     # ---Helper functions for preview updates
     def _get_settings_hash(self):
         """Create a hash of current settings for change detection."""
@@ -1110,9 +895,6 @@ class DataPreprocessing:
     def cleanup(self):
         """Clean up multiprocessing resources before destroying the object"""
         try:
-            self._stop_background_thumbnail_generation()
-            self._stop_video_thumbnail_generation()
-            
             self.reset_progress_variables()
 
             if hasattr(self, 'thumbnail_widget') and self.thumbnail_widget is not None:

--- a/widgets/thumbnail_widget.py
+++ b/widgets/thumbnail_widget.py
@@ -23,6 +23,8 @@ class ThumbnailWidget:
         self.last_mode_switch_time = 0  # For debouncing rapid toggles
         self.delete_pressed = False  # Flag for delete key press
         self._pending_render_paths = []  # Visible files still needing a rendered thumbnail
+        self._deferred_delete = []  # Textures to free at start of next render frame
+        self._frame_held_textures = []  # Strong refs for textures used in current draw list
     
     def create_placeholder_thumbnail(self, file_path):
         """Create a grey placeholder thumbnail with image name"""
@@ -140,6 +142,16 @@ class ThumbnailWidget:
         self.clear_thumbnails()
         self.clear_placeholder_thumbnails()
 
+    def _flush_deferred_deletes(self):
+        """Delete textures scheduled for deferred deletion (safe after prior frame rendered)."""
+        for tex in self._deferred_delete:
+            if tex is not None:
+                try:
+                    tex.delete()
+                except Exception:
+                    pass
+        self._deferred_delete.clear()
+
     def _cleanup_offscreen_placeholders(self, visible_files):
         """Free placeholder textures that are outside the visible + buffer range."""
         visible_set = set(visible_files)
@@ -147,10 +159,7 @@ class ThumbnailWidget:
         for fp in to_remove:
             tex = self.placeholder_textures.pop(fp)
             if tex is not None:
-                try:
-                    tex.delete()
-                except Exception:
-                    pass
+                self._deferred_delete.append(tex)
 
     def _cleanup_offscreen_thumbnails(self, visible_files):
         """Free rendered thumbnail textures that are outside the visible + buffer range."""
@@ -159,16 +168,16 @@ class ThumbnailWidget:
         for fp in to_remove:
             tex = self.thumbnails.pop(fp)
             if tex is not None:
-                try:
-                    tex.delete()
-                except Exception:
-                    pass
+                self._deferred_delete.append(tex)
 
     def get_pending_render_paths(self):
         """Return visible file paths that still need a rendered thumbnail."""
         return self._pending_render_paths
     
     def render_thumbnails(self, available_width, available_height):
+        self._flush_deferred_deletes()
+        self._frame_held_textures = []
+
         if not self.selected_files:
             message = "No images imported"
             text_width = imgui.calc_text_size(message)[0]
@@ -286,7 +295,8 @@ class ThumbnailWidget:
                 is_hovered = imgui.is_item_hovered()
 
                 imgui.set_cursor_screen_pos((cursor_pos[0], cursor_pos[1]))
-                imgui.image(texture.gl_id, thumb_size, thumb_size)
+                self._frame_held_textures.append(texture)
+                imgui.image(int(texture.gl_id), thumb_size, thumb_size)
 
                 if is_hovered or is_selected:
                     x1, y1 = cursor_pos
@@ -316,6 +326,7 @@ class ThumbnailWidget:
 
         if self.generate_thumbnails:
             self._pending_render_paths = [fp for fp in rendered_files if fp not in self.thumbnails]
+            
             self._cleanup_offscreen_thumbnails(rendered_files)
         else:
             self._pending_render_paths = []
@@ -357,6 +368,9 @@ class ThumbnailWidget:
         if thumbnail_data is not None:
             texture = self._create_texture_from_data(thumbnail_data)
             if texture is not None:
+                old = self.thumbnails.get(file_path)
+                if old is not None:
+                    self._deferred_delete.append(old)
                 self.thumbnails[file_path] = texture
     
     def _create_texture_from_data(self, thumbnail_data):
@@ -451,7 +465,9 @@ class ThumbnailWidget:
         """Clean up OpenGL textures and resources"""
         try:
             self.generate_thumbnails = False
-            
+            self._flush_deferred_deletes()
+            self._frame_held_textures = []
+
             for texture in self.thumbnails.values():
                 if texture is not None and hasattr(texture, 'delete') and callable(texture.delete):
                     try:

--- a/widgets/thumbnail_widget.py
+++ b/widgets/thumbnail_widget.py
@@ -13,7 +13,7 @@ from utils.dataset_preprocessing_utils import DatasetPreprocessingUtils
 
 
 def _render_thumbnail(file_path, thumbnail_size):
-    """Pure helper: render an image/video file into a square thumbnail np.array.
+    """Render an image/video file into a square thumbnail np.array.
 
     Runs in worker processes. Returns None on failure.
     """
@@ -57,12 +57,7 @@ def _render_thumbnail(file_path, thumbnail_size):
 
 def _auto_cache_capacity(thumbnail_size, vram_fraction=0.01,
                         min_slots=200, max_slots=5000, fallback=500):
-    """Return a thumbnail-cache size based on total CUDA VRAM.
-
-    Uses a small fraction of total VRAM (stable across the session) divided
-    by the per-thumbnail RGB byte cost, clamped to [min_slots, max_slots].
-    Returns `fallback` when CUDA is unavailable or queries fail.
-    """
+    """Return a thumbnail-cache size based on total CUDA VRAM."""
     bytes_per_thumb = max(1, thumbnail_size * thumbnail_size * 3)
     try:
         import torch
@@ -77,13 +72,7 @@ def _auto_cache_capacity(thumbnail_size, vram_fraction=0.01,
 
 
 class ThumbnailWidget:
-    """Widget for handling image thumbnails with caching and display.
-
-    Owns its own background worker process for rendered thumbnails. Each frame
-    `render_thumbnails()` writes the latest desired set of paths to a single-slot
-    request queue, and `poll()` consumes streamed results. A generation counter
-    invalidates stale results when the file list or render mode changes.
-    """
+    """Widget for handling image thumbnails with caching and display."""
 
     def __init__(self):
         self.thumbnail_size = 140  # Determines quality of thumbnails (resolution)
@@ -178,13 +167,7 @@ class ThumbnailWidget:
     # --- Render mode + worker lifecycle -------------------------------------
 
     def set_render_mode(self, enabled):
-        """Toggle whether the widget displays rendered thumbnails and feeds the worker.
-
-        Lazy-starts the worker on first enable. Disabling does NOT stop the worker
-        (so re-enabling is instant) and does NOT clear `self.thumbnails`.
-        Idempotent: only bumps generation on real state changes so callers can
-        invoke this every frame without dropping in-flight results.
-        """
+        """Toggle whether the widget displays rendered thumbnails and feeds the worker."""
         enabled = bool(enabled)
         self.generate_thumbnails = enabled
         if enabled != self._render_mode_active:
@@ -596,7 +579,6 @@ class ThumbnailWidget:
             'paths': needed,
             'size': self.thumbnail_size,
         }
-        # Latest-wins: drain any stale slot, then put the new payload.
         try:
             self._req_q.get_nowait()
         except Exception:

--- a/widgets/thumbnail_widget.py
+++ b/widgets/thumbnail_widget.py
@@ -1,696 +1,354 @@
-import cv2
 import os
 import math
 import collections
-import queue as queue_mod
-import multiprocessing as mp
+import queue
+
+from concurrent.futures import ThreadPoolExecutor
+
+import cv2
 import numpy as np
 import imgui
-from utils.gui_utils import gl_utils
-import gc
+import PIL.Image
+import PIL.ImageOps
 
+from utils.gui_utils import gl_utils
 from utils.dataset_preprocessing_utils import DatasetPreprocessingUtils
 
+# Threading and caching parameters
+WORKERS = min(4, max(1, os.cpu_count() or 1))
+MAX_IN_FLIGHT = WORKERS * 2
+CACHE_LIMIT = 5000
+BUFFER_ROWS = 50
+UPLOADS_PER_FRAME = 16
 
-def _render_thumbnail(file_path, thumbnail_size):
-    """Render an image/video file into a square thumbnail np.array.
+# Grid style
+THUMB_MIN = 120
+THUMB_MAX = 220
+GAP_X = 32
+GAP_Y = 16
 
-    Runs in worker processes. Returns None on failure.
+cv2.setNumThreads(1)  # we parallelize across threads ourselves
+
+
+def _render_thumbnail(file_path, size, padding):
+    """Decode an image/video file into a square ``size`` x ``size`` RGB array.
+
+    Non-square images are centered on a square canvas filled with ``padding``.
+    Runs on a worker thread. Returns None on failure.
     """
-    video_extensions = ['.mp4', '.avi', '.mov', '.mkv', '.wmv', '.flv', '.webm']
-    file_ext = os.path.splitext(file_path)[1].lower()
-
+    video_ext = ('.mp4', '.avi', '.mov', '.mkv', '.wmv', '.flv', '.webm')
     try:
-        if file_ext in video_extensions:
+        if file_path.lower().endswith(video_ext):
             cap = cv2.VideoCapture(file_path)
-            if not cap.isOpened():
-                return None
-            ret, frame = cap.read()
+            ok, frame = (cap.read() if cap.isOpened() else (False, None))
             cap.release()
-            if not ret:
+            if not ok:
                 return None
-            if len(frame.shape) == 3 and frame.shape[2] == 3:
+            if frame.ndim == 3 and frame.shape[2] == 3:
                 frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-            elif len(frame.shape) == 3 and frame.shape[2] == 4:
+            elif frame.ndim == 3 and frame.shape[2] == 4:
                 frame = cv2.cvtColor(frame, cv2.COLOR_BGRA2RGBA)
             img = frame
-            padding_value = 0
         else:
-            img = DatasetPreprocessingUtils().load_images(file_path)
-            padding_value = 26
+            # Decode JPEGs at reduced resolution: draft() lets libjpeg downsample
+            # while decoding (e.g. a 4K source straight to ~1/8 size), a big win
+            # since we only need a small thumbnail. No-op for non-JPEG formats.
+            # Done here, not in load_images, so that shared utility stays generic.
+            pil = PIL.Image.open(file_path)
+            pil.draft('RGB', (size, size))
+            pil = PIL.ImageOps.exif_transpose(pil)
+            img = DatasetPreprocessingUtils().load_images(pil)
 
         if img is None:
             return None
 
-        height, width = img.shape[:2]
-        max_dim = max(height, width)
-        channels = img.shape[2] if len(img.shape) > 2 else 1
-        canvas = np.full((max_dim, max_dim, channels), padding_value, dtype=img.dtype)
-        y_offset = (max_dim - height) // 2
-        x_offset = (max_dim - width) // 2
-        canvas[y_offset:y_offset + height, x_offset:x_offset + width] = img
-        return cv2.resize(canvas, (thumbnail_size, thumbnail_size), interpolation=cv2.INTER_AREA)
+        h, w = img.shape[:2]
+        side = max(h, w)
+        channels = img.shape[2] if img.ndim > 2 else 1
+        canvas = np.full((side, side, channels), padding, dtype=img.dtype)
+        y, x = (side - h) // 2, (side - w) // 2
+        canvas[y:y + h, x:x + w] = img
+        return cv2.resize(canvas, (size, size), interpolation=cv2.INTER_AREA)
     except Exception as e:
         print(f"Error rendering thumbnail for {file_path}: {e}")
         return None
 
 
-def _auto_cache_capacity(thumbnail_size, vram_fraction=0.01,
-                        min_slots=200, max_slots=5000, fallback=500):
-    """Return a thumbnail-cache size based on total CUDA VRAM."""
-    bytes_per_thumb = max(1, thumbnail_size * thumbnail_size * 3)
-    try:
-        import torch
-        if not torch.cuda.is_available():
-            return fallback
-        total_vram = torch.cuda.get_device_properties(0).total_memory
-        budget = total_vram * vram_fraction
-        capacity = int(budget // bytes_per_thumb)
-        return max(min_slots, min(max_slots, capacity))
-    except Exception:
-        return fallback
-
-
 class ThumbnailWidget:
-    """Widget for handling image thumbnails with caching and display."""
+    """Lazy, virtualized grid of image thumbnails.
 
-    def __init__(self):
-        self.thumbnail_size = 140  # Determines quality of thumbnails (resolution)
-        self.thumbnails = {}  
-        self.placeholder_textures = {}  
-        self.generate_thumbnails = False  # Show rendered thumbnails (when available) vs placeholders
+    Each frame we draw the visible cells, request decodes for any we are missing
+    (middle-out), and upload finished decodes as textures. Decoded textures are
+    held in a fixed-size LRU; cells not yet decoded show a flat loading square.
+    """
+
+    def __init__(self, padding_value=0):
+        self.thumbnail_size = 140
+        self.padding_value = padding_value
         self.selected_files = []
-        self.last_selected_idx = None
+
         self.selected_indices = []
+        self.last_selected_idx = None
         self.delete_pressed = False
 
-        self._deferred_delete = []
-        self._frame_held_textures = []
+        self._textures = collections.OrderedDict()  # path -> Texture, recent at end (LRU)
+        self._futures = {}                           # path -> Future for decodes in flight
+        self._done = queue.Queue()                   # (generation, path, ndarray|None)
+        self._generation = 0                         # bumped when the file list changes
+        self._trash = []                             # textures to delete next frame (GL-safe)
+        self._executor = None
 
-        # FIFO cache for rendered thumbnails outside the visible+buffer window.
-        self._cached_thumbnails = collections.OrderedDict()
-        self.max_cached_thumbnails = _auto_cache_capacity(self.thumbnail_size)
-
-        self._req_q = None       # mp.Queue(maxsize=1) — latest-wins payload
-        self._rep_q = None       # mp.Queue() — streamed results
-        self._worker_proc = None
-        self._generation = 0     # bumped on file-list / render-mode change
-        self._render_mode_active = False  # tracks worker-intent independently from the public flag
-
-    def create_placeholder_thumbnail(self, file_path):
-        """Create a grey placeholder thumbnail with image name"""
-        try:
-            size = self.thumbnail_size
-            canvas = np.full((size, size, 3), [128, 128, 128], dtype=np.uint8)
-
-            filename = os.path.splitext(os.path.basename(file_path))[0]
-
-            canvas = self._add_text_to_canvas(canvas, filename, size)
-
-            # Create texture
-            texture = gl_utils.Texture(
-                image=canvas,
-                width=size,
-                height=size,
-                channels=3
-            )
-
-            return texture
-        except Exception as e:
-            print(f"Failed to create placeholder thumbnail for {file_path}: {e}")
-            return None
-
-    def _add_text_to_canvas(self, canvas, text, size):
-        """Add text to the center of the thumbnail placeholder"""
-        try:
-            font_scale = 0.4
-            font_thickness = 1
-            font = cv2.FONT_HERSHEY_SIMPLEX
-
-            (text_width, text_height), baseline = cv2.getTextSize(text, font, font_scale, font_thickness)
-
-            max_width = int(size * 0.9)
-            if text_width > max_width:
-                char_width = text_width / len(text)
-                max_chars = int(max_width / char_width) - 3
-                text = text[:max_chars] + "..."
-                (text_width, text_height), baseline = cv2.getTextSize(text, font, font_scale, font_thickness)
-
-            x = (size - text_width) // 2
-            y = (size + text_height) // 2
-
-            cv2.putText(canvas, text, (x, y), font, font_scale, (255, 255, 255), font_thickness)
-
-            return canvas
-        except Exception as e:
-            print(f"Failed to add text to canvas: {e}")
-            return canvas
-
-    def get_thumbnail(self, file_path):
-        """Return rendered texture if available + render mode on, else placeholder.
-
-        Promotes a cached texture back into the active set when the path
-        re-enters the render window so subsequent demotions land it at the
-        tail of the FIFO again.
-        """
-        if self.generate_thumbnails:
-            if file_path in self.thumbnails:
-                return self.thumbnails[file_path]
-            cached = self._cached_thumbnails.pop(file_path, None)
-            if cached is not None:
-                self.thumbnails[file_path] = cached
-                return cached
-        if file_path not in self.placeholder_textures:
-            self.placeholder_textures[file_path] = self.create_placeholder_thumbnail(file_path)
-        return self.placeholder_textures[file_path]
-
-    # --- Render mode + worker lifecycle -------------------------------------
-
-    def set_render_mode(self, enabled):
-        """Toggle whether the widget displays rendered thumbnails and feeds the worker."""
-        enabled = bool(enabled)
-        self.generate_thumbnails = enabled
-        if enabled != self._render_mode_active:
-            self._render_mode_active = enabled
-            self._generation += 1
-        if enabled:
-            self._ensure_worker()
-
-    def _ensure_worker(self):
-        """Start the worker process and queues if not already running."""
-        if self._worker_proc is not None and self._worker_proc.is_alive():
-            return
-        self._req_q = mp.Queue(maxsize=1)
-        self._rep_q = mp.Queue()
-        self._worker_proc = mp.Process(
-            target=ThumbnailWidget._worker_main,
-            args=(self._req_q, self._rep_q),
-            daemon=True,
-        )
-        self._worker_proc.start()
-
-    def poll(self):
-        """Drain reply queue and apply results matching the current generation."""
-        if self._rep_q is None:
-            return
-        try:
-            while True:
-                msg = self._rep_q.get_nowait()
-                if msg.get('generation') != self._generation:
-                    continue
-                file_path = msg.get('file_path')
-                data = msg.get('data')
-                if file_path is None:
-                    continue
-                self.update_thumbnail_from_data(file_path, data)
-        except queue_mod.Empty:
-            return
-        except Exception as e:
-            print(f"Error polling thumbnail results: {e}")
-
-    def shutdown(self):
-        """Tear down the worker process and queues without raising BrokenPipeError."""
-        if self._req_q is not None:
-            try:
-                try:
-                    self._req_q.get_nowait()
-                except Exception:
-                    pass
-                try:
-                    self._req_q.put_nowait(None)
-                except Exception:
-                    pass
-            except Exception:
-                pass
-
-        proc = self._worker_proc
-        if proc is not None:
-            try:
-                proc.join(timeout=0.5)
-                if proc.is_alive():
-                    proc.terminate()
-                    proc.join(timeout=0.5)
-                if proc.is_alive():
-                    proc.kill()
-                    proc.join()
-            except Exception as e:
-                print(f"Error stopping thumbnail worker: {e}")
-
-        for q in (self._req_q, self._rep_q):
-            if q is None:
-                continue
-            try:
-                q.cancel_join_thread()
-                q.close()
-            except Exception:
-                pass
-
-        self._worker_proc = None
-        self._req_q = None
-        self._rep_q = None
-
-    @staticmethod
-    def _worker_main(req_q, rep_q):
-        """Worker entry point: latest-wins payload, preempts between images."""
-        current = None
-        idx = 0
-        while True:
-            payload = None
-            got_payload = False
-            try:
-                if current is None:
-                    payload = req_q.get(timeout=0.25)
-                else:
-                    payload = req_q.get_nowait()
-                got_payload = True
-            except queue_mod.Empty:
-                got_payload = False
-            except Exception:
-                return
-
-            if got_payload:
-                if payload is None:
-                    return 
-                if isinstance(payload, dict):
-                    current = payload
-                    idx = 0
-                else:
-                    continue
-
-            if current is None:
-                continue
-
-            paths = current.get('paths') or []
-            size = current.get('size', 140)
-            gen_id = current.get('generation', 0)
-
-            if idx >= len(paths):
-                current = None
-                continue
-
-            path = paths[idx]
-            idx += 1
-            data = _render_thumbnail(path, size)
-            try:
-                rep_q.put({'generation': gen_id, 'file_path': path, 'data': data})
-            except Exception:
-                return
-
-    # --- File list management -----------------------------------------------
-
-    def set_thumbnail_mode(self, generate_thumbnails, prev_thumbnail_mode=None):
-        """Public toggle: route to set_render_mode and clear placeholders.
-
-        Rendered cache survives the toggle so re-enabling is instant.
-        """
-        prev = prev_thumbnail_mode if prev_thumbnail_mode is not None else self.generate_thumbnails
-        if prev == generate_thumbnails:
-            return
-        self.clear_placeholder_thumbnails()
-        self.set_render_mode(generate_thumbnails)
+    # --- Public API ---------------------------------------------------------
 
     def update_thumbnails(self, file_paths):
-        """Update the file list. Textures are created lazily during render."""
+        """Replace the file list. Textures for files that are gone are freed."""
         self.selected_files = file_paths
-        self._generation += 1
-        valid = set(file_paths)
-        stale = [fp for fp in self._cached_thumbnails if fp not in valid]
-        for fp in stale:
-            tex = self._cached_thumbnails.pop(fp)
-            if tex is not None:
-                self._deferred_delete.append(tex)
-
-    def clear_thumbnails(self):
-        """Defer-delete all rendered thumbnails."""
-        for tex in self.thumbnails.values():
-            if tex is not None:
-                self._deferred_delete.append(tex)
-        self.thumbnails.clear()
-
-    def clear_placeholder_thumbnails(self):
-        """Defer-delete all placeholder thumbnails."""
-        for tex in self.placeholder_textures.values():
-            if tex is not None:
-                self._deferred_delete.append(tex)
-        self.placeholder_textures.clear()
-
-    def clear_cached_thumbnails(self):
-        """Defer-delete all FIFO-cached offscreen thumbnails."""
-        for tex in self._cached_thumbnails.values():
-            if tex is not None:
-                self._deferred_delete.append(tex)
-        self._cached_thumbnails.clear()
-
-    def clear_all_thumbnails(self):
-        """Clear actual, cached, and placeholder thumbnails"""
-        self.clear_thumbnails()
-        self.clear_cached_thumbnails()
-        self.clear_placeholder_thumbnails()
-
-    def _flush_deferred_deletes(self):
-        """Delete textures scheduled for deferred deletion (safe after prior frame rendered)."""
-        for tex in self._deferred_delete:
-            if tex is not None:
-                try:
-                    tex.delete()
-                except Exception:
-                    pass
-        self._deferred_delete.clear()
-
-    def _cleanup_offscreen_placeholders(self, visible_files):
-        """Free placeholder textures that are outside the visible + buffer range."""
-        visible_set = set(visible_files)
-        to_remove = [fp for fp in self.placeholder_textures if fp not in visible_set]
-        for fp in to_remove:
-            tex = self.placeholder_textures.pop(fp)
-            if tex is not None:
-                self._deferred_delete.append(tex)
-
-    def _demote_offscreen_thumbnails(self, visible_files):
-        """Move rendered thumbnails outside the render window into the FIFO cache,
-        evicting the oldest cached entries once the limit is exceeded."""
-        visible_set = set(visible_files)
-        to_demote = [fp for fp in self.thumbnails if fp not in visible_set]
-        for fp in to_demote:
-            tex = self.thumbnails.pop(fp)
-            if tex is None:
-                continue
-
-            if fp in self._cached_thumbnails:
-                old = self._cached_thumbnails.pop(fp)
-                if old is not None and old is not tex:
-                    self._deferred_delete.append(old)
-            self._cached_thumbnails[fp] = tex
-
-        while len(self._cached_thumbnails) > self.max_cached_thumbnails:
-            _, evicted = self._cached_thumbnails.popitem(last=False)
-            if evicted is not None:
-                self._deferred_delete.append(evicted)
-
-    # --- Rendering ----------------------------------------------------------
+        self._generation += 1          # in-flight results for the old list become stale
+        self._cancel_all_futures()
+        keep = set(file_paths)
+        for path in [p for p in self._textures if p not in keep]:
+            self._trash.append(self._textures.pop(path))
 
     def render_thumbnails(self, available_width, available_height):
-        self._flush_deferred_deletes()
-        self._frame_held_textures = []
+        self._flush_trash()
 
-        if not self.selected_files:
-            message = "No images imported"
-            text_width = imgui.calc_text_size(message)[0]
-            text_height = imgui.get_text_line_height()
-
-            center_x = (available_width - text_width) / 2
-            center_y = (available_height - text_height) / 2
-
-            imgui.set_cursor_pos_x(center_x)
-            imgui.set_cursor_pos_y(center_y)
-
-            imgui.text_colored(message, 0.5, 0.5, 0.5, 1.0)
+        files = self.selected_files
+        if not files:
+            self._draw_empty_message(available_width, available_height)
             return
 
-        min_thumb_size = 120
-        max_thumb_size = 220
-        spacing_x = 32
-        spacing_y = 16
-        grid_padding = 6
-        n = len(self.selected_files)
+        per_row, thumb, row_h, left = self._grid_metrics(available_width)
+        rows = math.ceil(len(files) / per_row)
 
-        inner_width = available_width - 2 * grid_padding
+        ox, oy = imgui.get_cursor_pos()
+        # Reserve the full grid height once so the scroll area never changes
+        # size between frames -- this is what stops the drag-scroll jitter.
+        imgui.dummy(available_width, rows * row_h)
 
-        thumbnails_per_row = max(1, int((inner_width + spacing_x) // (min_thumb_size + spacing_x)))
-        thumb_size = min(
-            max_thumb_size,
-            max(min_thumb_size, int((inner_width - (thumbnails_per_row - 1) * spacing_x) // thumbnails_per_row))
-        )
-
-        total_row_width = thumbnails_per_row * thumb_size + (thumbnails_per_row - 1) * spacing_x
-        left_margin = grid_padding + max(0, (inner_width - total_row_width) // 2)
-
-        text_line_height = imgui.get_text_line_height_with_spacing()
-        row_height = thumb_size + spacing_y + text_line_height
-        total_rows = math.ceil(n / thumbnails_per_row)
+        self._handle_shortcuts()
 
         scroll_y = imgui.get_scroll_y()
-        first_visible_row = max(0, int(scroll_y / row_height))
-        last_visible_row = int((scroll_y + available_height) / row_height)
+        first_row = max(0, int(scroll_y / row_h) - BUFFER_ROWS)
+        last_row = min(rows, int((scroll_y + available_height) / row_h) + 1 + BUFFER_ROWS)
+        first, last = first_row * per_row, min(len(files), last_row * per_row)
 
-        thumbnail_buffer = 100
-        buffer_rows = math.ceil(thumbnail_buffer / thumbnails_per_row)
-        first_render_row = max(0, first_visible_row - buffer_rows)
-        last_render_row = min(total_rows - 1, last_visible_row + buffer_rows)
+        for idx in range(first, last):
+            row, col = divmod(idx, per_row)
+            x = ox + left + col * (thumb + GAP_X)
+            y = oy + row * row_h
+            self._draw_thumbnail(idx, files[idx], x, y, thumb)
 
-        first_render_idx = first_render_row * thumbnails_per_row
-        last_render_idx = min(n, (last_render_row + 1) * thumbnails_per_row)
-        first_render_idx = min(first_render_idx, last_render_idx)
+        self._request_decodes(files, first, last)
+        self._evict()
 
-        if first_render_row > 0:
-            imgui.dummy(available_width, first_render_row * row_height)
-
-        ctrl_down = imgui.is_key_down(341) or imgui.is_key_down(345)
-        shift_down = imgui.is_key_down(340) or imgui.is_key_down(344)
-        a_pressed = imgui.is_key_pressed(65)
-        delete_pressed = imgui.is_key_pressed(261) or imgui.is_key_pressed(259)
-
-        if ctrl_down and a_pressed:
-            self.select_all()
-
-        if delete_pressed and (self.selected_indices or self.last_selected_idx is not None):
-            self.delete_pressed = True
-
-        rendered_files = []
-
-        for idx in range(first_render_idx, last_render_idx):
-            file_path = self.selected_files[idx]
-            texture = self.get_thumbnail(file_path)
-            rendered_files.append(file_path)
-
-            if texture is not None and hasattr(texture, 'gl_id') and texture.gl_id is not None:
-                col = idx % thumbnails_per_row
-
-                if col == 0:
-                    imgui.dummy(left_margin, 0)
-                    imgui.same_line(spacing=0)
-                elif col > 0:
-                    imgui.same_line(spacing=spacing_x)
-
-                imgui.begin_group()
-                imgui.push_id(str(idx))
-                is_hovered = False
-
-                if self.selected_indices:
-                    is_selected = (idx in self.selected_indices)
-                else:
-                    is_selected = (self.last_selected_idx == idx)
-
-                cursor_pos = imgui.get_cursor_screen_pos()
-                draw_list = imgui.get_window_draw_list()
-                frame_color = (0.8, 0.4, 0.1, 1.0) if is_selected else (1.0, 0.8, 0.2, 0.7)
-                border_thickness = 3 if is_selected else 2
-
-                if imgui.invisible_button("thumb", thumb_size, thumb_size):
-                    if shift_down and self.last_selected_idx is not None:
-                        start = min(self.last_selected_idx, idx)
-                        end = max(self.last_selected_idx, idx)
-                        self.selected_indices = list(range(start, end + 1))
-                    elif ctrl_down:
-                        if idx in self.selected_indices:
-                            self.selected_indices.remove(idx)
-                        else:
-                            self.selected_indices.append(idx)
-                        self.last_selected_idx = idx
-                    else:
-                        self.selected_indices = [idx]
-                        self.last_selected_idx = idx
-
-                is_hovered = imgui.is_item_hovered()
-
-                imgui.set_cursor_screen_pos((cursor_pos[0], cursor_pos[1]))
-                self._frame_held_textures.append(texture)
-                imgui.image(int(texture.gl_id), thumb_size, thumb_size)
-
-                if is_hovered or is_selected:
-                    x1, y1 = cursor_pos
-                    x2, y2 = x1 + thumb_size, y1 + thumb_size
-                    draw_list.add_rect(x1, y1, x2, y2, imgui.get_color_u32_rgba(*frame_color), rounding=6, thickness=border_thickness)
-
-                filename = os.path.basename(file_path)
-                if len(filename) > 15:
-                    filename = filename[:12] + "..."
-                text_width = imgui.calc_text_size(filename)[0]
-                cursor_x = imgui.get_cursor_pos_x()
-                imgui.set_cursor_pos_x(cursor_x + (thumb_size - text_width) / 2)
-                imgui.text(filename)
-                imgui.pop_id()
-                imgui.end_group()
-
-                if col == thumbnails_per_row - 1:
-                    imgui.new_line()
-                    imgui.dummy(0, spacing_y)
-
-        remaining_rows = total_rows - 1 - last_render_row
-        if remaining_rows > 0:
-            imgui.dummy(available_width, remaining_rows * row_height)
-
-        self._cleanup_offscreen_placeholders(rendered_files)
-        self._demote_offscreen_thumbnails(rendered_files)
-
-        # Schedule worker to render the visible/buffer set, viewport-first.
-        if self.generate_thumbnails:
-            self._schedule_render_requests(
-                first_render_idx, last_render_idx,
-                first_visible_row, last_visible_row,
-                thumbnails_per_row,
-            )
-
-    def _schedule_render_requests(self, first_render_idx, last_render_idx,
-                                  first_visible_row, last_visible_row,
-                                  thumbnails_per_row):
-        """Build a center-out list of needed paths and post it to the worker slot."""
-        if self._req_q is None:
-            self._ensure_worker()
-            if self._req_q is None:
+    def poll(self):
+        """Upload finished decodes as textures (bounded per frame)."""
+        for _ in range(UPLOADS_PER_FRAME):
+            try:
+                generation, path, data = self._done.get_nowait()
+            except queue.Empty:
                 return
+            self._futures.pop(path, None)
+            if generation != self._generation or data is None:
+                continue
+            texture = self._make_texture(data)
+            if texture is not None:
+                self._textures[path] = texture
+                self._textures.move_to_end(path)
 
-        visible_first_idx = max(first_render_idx, first_visible_row * thumbnails_per_row)
-        visible_last_idx = min(last_render_idx, (last_visible_row + 1) * thumbnails_per_row)
-        visible_first_idx = min(max(visible_first_idx, first_render_idx), last_render_idx)
-        visible_last_idx = min(max(visible_last_idx, first_render_idx), last_render_idx)
+    def cleanup(self):
+        """Stop workers and free every texture."""
+        if self._executor is not None:
+            self._executor.shutdown(wait=False, cancel_futures=True)
+            self._executor = None
+        self._drain_done()
+        self._cancel_all_futures()
+        for texture in list(self._textures.values()) + self._trash:
+            self._delete(texture)
+        self._textures.clear()
+        self._trash.clear()
+        self.selected_files = []
+        self.selected_indices = []
+        self.last_selected_idx = None
 
-        ordered_indices = list(range(visible_first_idx, visible_last_idx))
-        above = list(range(visible_first_idx - 1, first_render_idx - 1, -1))
-        below = list(range(visible_last_idx, last_render_idx))
-        a = b = 0
-        while a < len(above) or b < len(below):
-            if b < len(below):
-                ordered_indices.append(below[b])
-                b += 1
-            if a < len(above):
-                ordered_indices.append(above[a])
-                a += 1
-
-        n = len(self.selected_files)
-        needed = [self.selected_files[i]
-                  for i in ordered_indices
-                  if 0 <= i < n and self.selected_files[i] not in self.thumbnails]
-        if not needed:
-            return
-
-        payload = {
-            'generation': self._generation,
-            'paths': needed,
-            'size': self.thumbnail_size,
-        }
-        try:
-            self._req_q.get_nowait()
-        except Exception:
-            pass
-        try:
-            self._req_q.put_nowait(payload)
-        except Exception:
-            pass
-
-    # --- Selection / utilities ---------------------------------------------
-
-    def get_thumbnail_count(self):
-        """Get the number of thumbnails"""
-        return len(self.selected_files)
-
-    def get_selected_files(self):
-        """Get the list of selected files"""
-        return self.selected_files.copy()
+    # --- Selection ----------------------------------------------------------
 
     def select_all(self):
-        """Select all images"""
         self.selected_indices = list(range(len(self.selected_files)))
+        self.last_selected_idx = None
+
+    def clear_selected(self):
+        self.selected_indices = []
         self.last_selected_idx = None
 
     def get_selected_indices(self):
         if self.selected_indices:
             return sorted(set(self.selected_indices))
-        elif self.last_selected_idx is not None:
+        if self.last_selected_idx is not None:
             return [self.last_selected_idx]
         return []
 
-    def clear_selected(self):
-        self.last_selected_idx = None
-        self.selected_indices = []
-
     def is_delete_pressed(self):
-        """Check if delete was pressed and reset the flag"""
-        if self.delete_pressed:
-            self.delete_pressed = False
-            return True
-        return False
+        """Return True once if delete was pressed since the last call."""
+        pressed, self.delete_pressed = self.delete_pressed, False
+        return pressed
 
-    def update_thumbnail_from_data(self, file_path, thumbnail_data):
-        """Install a worker result as a rendered texture, deferring old texture deletion."""
-        if thumbnail_data is None:
-            return
-        texture = self._create_texture_from_data(thumbnail_data)
-        if texture is None:
-            return
-        old = self.thumbnails.get(file_path)
-        if old is not None:
-            self._deferred_delete.append(old)
-        self.thumbnails[file_path] = texture
+    # --- Drawing ------------------------------------------------------------
 
-    def _create_texture_from_data(self, thumbnail_data):
-        """Create OpenGL texture from thumbnail data"""
+    def _grid_metrics(self, available_width):
+        """Return (per_row, thumb_size, row_height, left_margin) for the grid."""
+        inner = available_width - 12
+        per_row = max(1, int((inner + GAP_X) // (THUMB_MIN + GAP_X)))
+        thumb = min(THUMB_MAX, max(THUMB_MIN, int((inner - (per_row - 1) * GAP_X) // per_row)))
+        row_width = per_row * thumb + (per_row - 1) * GAP_X
+        left = 6 + max(0, (inner - row_width) // 2)
+        row_height = thumb + GAP_Y + imgui.get_text_line_height_with_spacing()
+        return per_row, thumb, row_height, left
+
+    def _draw_thumbnail(self, idx, path, x, y, thumb):
+        imgui.set_cursor_pos((x, y))
+        imgui.push_id(str(idx))
+
+        sx, sy = imgui.get_cursor_screen_pos()
+        if imgui.invisible_button("t", thumb, thumb):
+            self._select(idx)
+        hovered = imgui.is_item_hovered()
+        selected = (idx in self.selected_indices
+                    or (not self.selected_indices and idx == self.last_selected_idx))
+
+        draw = imgui.get_window_draw_list()
+        texture = self._textures.get(path)
+        if texture is not None and texture.gl_id is not None:
+            self._textures.move_to_end(path)       # mark recently seen for the LRU
+            imgui.set_cursor_pos((x, y))
+            imgui.image(int(texture.gl_id), thumb, thumb)
+        else:
+            draw.add_rect_filled(sx, sy, sx + thumb, sy + thumb,
+                                 imgui.get_color_u32_rgba(0.18, 0.18, 0.18, 1.0), rounding=6)
+
+        if hovered or selected:
+            color = (0.8, 0.4, 0.1, 1.0) if selected else (1.0, 0.8, 0.2, 0.7)
+            draw.add_rect(sx, sy, sx + thumb, sy + thumb,
+                          imgui.get_color_u32_rgba(*color), rounding=6,
+                          thickness=3 if selected else 2)
+
+        name = os.path.basename(path)
+        if len(name) > 15:
+            name = name[:12] + "..."
+        text_x = x + (thumb - imgui.calc_text_size(name)[0]) / 2
+        imgui.set_cursor_pos((text_x, y + thumb))
+        imgui.text(name)
+
+        imgui.pop_id()
+
+    def _draw_empty_message(self, width, height):
+        message = "No images imported"
+        text_width = imgui.calc_text_size(message)[0]
+        imgui.set_cursor_pos(((width - text_width) / 2,
+                              (height - imgui.get_text_line_height()) / 2))
+        imgui.text_colored(message, 0.5, 0.5, 0.5, 1.0)
+
+    def _select(self, idx):
+        ctrl = imgui.is_key_down(341) or imgui.is_key_down(345)
+        shift = imgui.is_key_down(340) or imgui.is_key_down(344)
+        if shift and self.last_selected_idx is not None:
+            lo, hi = sorted((self.last_selected_idx, idx))
+            self.selected_indices = list(range(lo, hi + 1))
+        elif ctrl:
+            if idx in self.selected_indices:
+                self.selected_indices.remove(idx)
+            else:
+                self.selected_indices.append(idx)
+            self.last_selected_idx = idx
+        else:
+            self.selected_indices = [idx]
+            self.last_selected_idx = idx
+
+    def _handle_shortcuts(self):
+        ctrl = imgui.is_key_down(341) or imgui.is_key_down(345)
+        if ctrl and imgui.is_key_pressed(65):                       # Ctrl+A
+            self.select_all()
+        if imgui.is_key_pressed(261) or imgui.is_key_pressed(259):  # Delete / Backspace
+            if self.selected_indices or self.last_selected_idx is not None:
+                self.delete_pressed = True
+
+    # --- Decode scheduling --------------------------------------------------
+
+    def _request_decodes(self, files, first, last):
+        """Keep the worker pool focused on the current window.
+
+        Cancel queued decodes that scrolled out of view, then submit the missing
+        ones -- bounded and filling outward from the center -- so a fast scroll
+        never queues a backlog for rows it flew past and the cursor's thumbnails
+        always load first.
+        """
+        window = set(files[first:last])
+        for path in [p for p in self._futures if p not in window]:
+            if self._futures[path].cancel():   # only succeeds if it had not started
+                del self._futures[path]
+
+        if first >= last:
+            return
+
+        slots = MAX_IN_FLIGHT - len(self._futures)
+        if slots <= 0:
+            return
+        center = (first + last) // 2
+        todo = [i for i in range(first, last)
+                if files[i] not in self._textures and files[i] not in self._futures]
+        todo.sort(key=lambda i: abs(i - center))
+        executor = self._get_executor()
+        for i in todo[:slots]:
+            path = files[i]
+            self._futures[path] = executor.submit(self._decode, path, self._generation)
+
+    def _cancel_all_futures(self):
+        for future in self._futures.values():
+            future.cancel()
+        self._futures.clear()
+
+    def _decode(self, path, generation):
+        data = _render_thumbnail(path, self.thumbnail_size, self.padding_value)
+        self._done.put((generation, path, data))
+
+    def _get_executor(self):
+        if self._executor is None:
+            self._executor = ThreadPoolExecutor(max_workers=WORKERS, thread_name_prefix="thumb")
+        return self._executor
+
+    # --- Texture / cache housekeeping --------------------------------------
+
+    def _make_texture(self, data):
         try:
-            return gl_utils.Texture(
-                image=thumbnail_data,
-                width=thumbnail_data.shape[1],
-                height=thumbnail_data.shape[0],
-                channels=thumbnail_data.shape[2] if len(thumbnail_data.shape) > 2 else 1
-            )
+            channels = data.shape[2] if data.ndim > 2 else 1
+            return gl_utils.Texture(image=data, width=data.shape[1],
+                                    height=data.shape[0], channels=channels)
         except Exception as e:
-            print(f"Error creating texture from thumbnail data: {e}")
+            print(f"Error creating thumbnail texture: {e}")
             return None
 
-    # --- Cleanup ------------------------------------------------------------
+    def _evict(self):
+        while len(self._textures) > CACHE_LIMIT:
+            _, texture = self._textures.popitem(last=False)  # oldest = least recently seen
+            self._trash.append(texture)
 
-    def cleanup(self):
-        """Tear down worker and free all textures."""
-        try:
-            self.shutdown()
-            self.generate_thumbnails = False
-            self._flush_deferred_deletes()
-            self._frame_held_textures = []
+    def _flush_trash(self):
+        """Delete last frame's discarded textures, now that that frame has rendered."""
+        for texture in self._trash:
+            self._delete(texture)
+        self._trash.clear()
 
-            for texture in self.thumbnails.values():
-                if texture is not None and hasattr(texture, 'delete') and callable(texture.delete):
-                    try:
-                        if texture.gl_id is not None:
-                            texture.delete()
-                    except Exception as e:
-                        print(f"Error deleting thumbnail texture: {e}")
-            self.thumbnails.clear()
+    def _drain_done(self):
+        while True:
+            try:
+                self._done.get_nowait()
+            except queue.Empty:
+                return
 
-            for texture in self._cached_thumbnails.values():
-                if texture is not None and hasattr(texture, 'delete') and callable(texture.delete):
-                    try:
-                        if texture.gl_id is not None:
-                            texture.delete()
-                    except Exception as e:
-                        print(f"Error deleting cached thumbnail texture: {e}")
-            self._cached_thumbnails.clear()
-
-            for texture in self.placeholder_textures.values():
-                if texture is not None and hasattr(texture, 'delete') and callable(texture.delete):
-                    try:
-                        if texture.gl_id is not None:
-                            texture.delete()
-                    except Exception as e:
-                        print(f"Error deleting placeholder texture: {e}")
-            self.placeholder_textures.clear()
-
-            self.selected_files = []
-            self.selected_indices = []
-            self.last_selected_idx = None
-
-            gc.collect()
-
-        except Exception as e:
-            print(f"Warning: Error during thumbnail widget cleanup: {e}")
-
-    def __del__(self):
-        pass
+    @staticmethod
+    def _delete(texture):
+        if texture is not None and texture.gl_id is not None:
+            try:
+                texture.delete()
+            except Exception:
+                pass

--- a/widgets/thumbnail_widget.py
+++ b/widgets/thumbnail_widget.py
@@ -55,6 +55,27 @@ def _render_thumbnail(file_path, thumbnail_size):
         return None
 
 
+def _auto_cache_capacity(thumbnail_size, vram_fraction=0.01,
+                        min_slots=200, max_slots=5000, fallback=500):
+    """Return a thumbnail-cache size based on total CUDA VRAM.
+
+    Uses a small fraction of total VRAM (stable across the session) divided
+    by the per-thumbnail RGB byte cost, clamped to [min_slots, max_slots].
+    Returns `fallback` when CUDA is unavailable or queries fail.
+    """
+    bytes_per_thumb = max(1, thumbnail_size * thumbnail_size * 3)
+    try:
+        import torch
+        if not torch.cuda.is_available():
+            return fallback
+        total_vram = torch.cuda.get_device_properties(0).total_memory
+        budget = total_vram * vram_fraction
+        capacity = int(budget // bytes_per_thumb)
+        return max(min_slots, min(max_slots, capacity))
+    except Exception:
+        return fallback
+
+
 class ThumbnailWidget:
     """Widget for handling image thumbnails with caching and display.
 
@@ -79,7 +100,7 @@ class ThumbnailWidget:
 
         # FIFO cache for rendered thumbnails outside the visible+buffer window.
         self._cached_thumbnails = collections.OrderedDict()
-        self.max_cached_thumbnails = 1000
+        self.max_cached_thumbnails = _auto_cache_capacity(self.thumbnail_size)
 
         self._req_q = None       # mp.Queue(maxsize=1) — latest-wins payload
         self._rep_q = None       # mp.Queue() — streamed results

--- a/widgets/thumbnail_widget.py
+++ b/widgets/thumbnail_widget.py
@@ -1,41 +1,99 @@
 import cv2
 import os
 import math
+import queue as queue_mod
+import multiprocessing as mp
 import numpy as np
 import imgui
 from utils.gui_utils import gl_utils
-import time
 import gc
 
 from utils.dataset_preprocessing_utils import DatasetPreprocessingUtils
 
+
+def _render_thumbnail(file_path, thumbnail_size):
+    """Pure helper: render an image/video file into a square thumbnail np.array.
+
+    Runs in worker processes. Returns None on failure.
+    """
+    video_extensions = ['.mp4', '.avi', '.mov', '.mkv', '.wmv', '.flv', '.webm']
+    file_ext = os.path.splitext(file_path)[1].lower()
+
+    try:
+        if file_ext in video_extensions:
+            cap = cv2.VideoCapture(file_path)
+            if not cap.isOpened():
+                return None
+            ret, frame = cap.read()
+            cap.release()
+            if not ret:
+                return None
+            if len(frame.shape) == 3 and frame.shape[2] == 3:
+                frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            elif len(frame.shape) == 3 and frame.shape[2] == 4:
+                frame = cv2.cvtColor(frame, cv2.COLOR_BGRA2RGBA)
+            img = frame
+            padding_value = 0
+        else:
+            img = DatasetPreprocessingUtils().load_images(file_path)
+            padding_value = 26
+
+        if img is None:
+            return None
+
+        height, width = img.shape[:2]
+        max_dim = max(height, width)
+        channels = img.shape[2] if len(img.shape) > 2 else 1
+        canvas = np.full((max_dim, max_dim, channels), padding_value, dtype=img.dtype)
+        y_offset = (max_dim - height) // 2
+        x_offset = (max_dim - width) // 2
+        canvas[y_offset:y_offset + height, x_offset:x_offset + width] = img
+        return cv2.resize(canvas, (thumbnail_size, thumbnail_size), interpolation=cv2.INTER_AREA)
+    except Exception as e:
+        print(f"Error rendering thumbnail for {file_path}: {e}")
+        return None
+
+
 class ThumbnailWidget:
-    """Widget for handling image thumbnails with caching and display"""
-    
+    """Widget for handling image thumbnails with caching and display.
+
+    Owns its own background worker process for rendered thumbnails. Each frame
+    `render_thumbnails()` writes the latest desired set of paths to a single-slot
+    request queue, and `poll()` consumes streamed results. A generation counter
+    invalidates stale results when the file list or render mode changes.
+    """
+
     def __init__(self):
-        self.thumbnail_size = 140 # Determines quality of thumbnails (resolution)
-        self.thumbnails = {}  # Cache for thumbnail textures
+        self.thumbnail_size = 140  # Determines quality of thumbnails (resolution)
+        self.thumbnails = {}  # Cache for rendered thumbnail textures
         self.placeholder_textures = {}  # Cache for placeholder textures
-        self.generate_thumbnails = False  # Default to performance mode (no thumbnails, only placeholders)
+        self.generate_thumbnails = False  # Show rendered thumbnails (when available) vs placeholders
         self.selected_files = []
         self.last_selected_idx = None
-        self.selected_indices = []  # For multi-selection
-        self.last_mode_switch_time = 0  # For debouncing rapid toggles
-        self.delete_pressed = False  # Flag for delete key press
-        self._pending_render_paths = []  # Visible files still needing a rendered thumbnail
-        self._deferred_delete = []  # Textures to free at start of next render frame
-        self._frame_held_textures = []  # Strong refs for textures used in current draw list
-    
+        self.selected_indices = []
+        self.delete_pressed = False
+
+        # Texture lifetime helpers (deferred deletion + per-frame strong refs)
+        self._deferred_delete = []
+        self._frame_held_textures = []
+
+        # Background worker IPC for rendered thumbnails
+        self._req_q = None       # mp.Queue(maxsize=1) — latest-wins payload
+        self._rep_q = None       # mp.Queue() — streamed results
+        self._worker_proc = None
+        self._generation = 0     # bumped on file-list / render-mode change
+        self._render_mode_active = False  # tracks worker-intent independently from the public flag
+
     def create_placeholder_thumbnail(self, file_path):
         """Create a grey placeholder thumbnail with image name"""
         try:
             size = self.thumbnail_size
-            canvas = np.full((size, size, 3), [128, 128, 128], dtype=np.uint8)  
-            
+            canvas = np.full((size, size, 3), [128, 128, 128], dtype=np.uint8)
+
             filename = os.path.splitext(os.path.basename(file_path))[0]
-            
+
             canvas = self._add_text_to_canvas(canvas, filename, size)
-            
+
             # Create texture
             texture = gl_utils.Texture(
                 image=canvas,
@@ -43,100 +101,223 @@ class ThumbnailWidget:
                 height=size,
                 channels=3
             )
-            
+
             return texture
         except Exception as e:
             print(f"Failed to create placeholder thumbnail for {file_path}: {e}")
             return None
-    
+
     def _add_text_to_canvas(self, canvas, text, size):
         """Add text to the center of the thumbnail placeholder"""
         try:
             font_scale = 0.4
             font_thickness = 1
             font = cv2.FONT_HERSHEY_SIMPLEX
-            
+
             (text_width, text_height), baseline = cv2.getTextSize(text, font, font_scale, font_thickness)
-            
-            max_width = int(size * 0.9)  
+
+            max_width = int(size * 0.9)
             if text_width > max_width:
                 char_width = text_width / len(text)
-                max_chars = int(max_width / char_width) - 3 
+                max_chars = int(max_width / char_width) - 3
                 text = text[:max_chars] + "..."
                 (text_width, text_height), baseline = cv2.getTextSize(text, font, font_scale, font_thickness)
-            
+
             x = (size - text_width) // 2
             y = (size + text_height) // 2
-            
-            # Add text to canvas
+
             cv2.putText(canvas, text, (x, y), font, font_scale, (255, 255, 255), font_thickness)
-            
+
             return canvas
         except Exception as e:
             print(f"Failed to add text to canvas: {e}")
             return canvas
-    
+
     def get_thumbnail(self, file_path):
-        """Get thumbnail based on generate_thumbnails setting"""
-        if self.generate_thumbnails:
-            if file_path in self.thumbnails:
-                return self.thumbnails[file_path]
-            else:
-                if file_path not in self.placeholder_textures:
-                    self.placeholder_textures[file_path] = self.create_placeholder_thumbnail(file_path)
-                return self.placeholder_textures[file_path]
-        else:
-            if file_path not in self.placeholder_textures:
-                self.placeholder_textures[file_path] = self.create_placeholder_thumbnail(file_path)
-            return self.placeholder_textures[file_path]
-    
-    def set_thumbnail_mode(self, generate_thumbnails, prev_thumbnail_mode=None):
-        """Set thumbnail generation mode (placeholder or actual rendered thumbnails) and clear appropriate cache"""
-        prev_mode = prev_thumbnail_mode if prev_thumbnail_mode is not None else self.generate_thumbnails
-        if prev_mode != generate_thumbnails:
-            current_time = time.time()
-            
-            # Debounce rapid toggling (prevent switches faster than 100ms)
-            if current_time - self.last_mode_switch_time < 0.1:
+        """Return rendered texture if available + render mode on, else placeholder."""
+        if self.generate_thumbnails and file_path in self.thumbnails:
+            return self.thumbnails[file_path]
+        if file_path not in self.placeholder_textures:
+            self.placeholder_textures[file_path] = self.create_placeholder_thumbnail(file_path)
+        return self.placeholder_textures[file_path]
+
+    # --- Render mode + worker lifecycle -------------------------------------
+
+    def set_render_mode(self, enabled):
+        """Toggle whether the widget displays rendered thumbnails and feeds the worker.
+
+        Lazy-starts the worker on first enable. Disabling does NOT stop the worker
+        (so re-enabling is instant) and does NOT clear `self.thumbnails`.
+        Idempotent: only bumps generation on real state changes so callers can
+        invoke this every frame without dropping in-flight results.
+        """
+        enabled = bool(enabled)
+        self.generate_thumbnails = enabled
+        if enabled != self._render_mode_active:
+            self._render_mode_active = enabled
+            self._generation += 1
+        if enabled:
+            self._ensure_worker()
+
+    def _ensure_worker(self):
+        """Start the worker process and queues if not already running."""
+        if self._worker_proc is not None and self._worker_proc.is_alive():
+            return
+        self._req_q = mp.Queue(maxsize=1)
+        self._rep_q = mp.Queue()
+        self._worker_proc = mp.Process(
+            target=ThumbnailWidget._worker_main,
+            args=(self._req_q, self._rep_q),
+            daemon=True,
+        )
+        self._worker_proc.start()
+
+    def poll(self):
+        """Drain reply queue and apply results matching the current generation."""
+        if self._rep_q is None:
+            return
+        try:
+            while True:
+                msg = self._rep_q.get_nowait()
+                if msg.get('generation') != self._generation:
+                    continue
+                file_path = msg.get('file_path')
+                data = msg.get('data')
+                if file_path is None:
+                    continue
+                self.update_thumbnail_from_data(file_path, data)
+        except queue_mod.Empty:
+            return
+        except Exception as e:
+            print(f"Error polling thumbnail results: {e}")
+
+    def shutdown(self):
+        """Tear down the worker process and queues without raising BrokenPipeError."""
+        # Send wake/exit sentinel so worker can exit cleanly if it's blocking on get().
+        if self._req_q is not None:
+            try:
+                # Drain anything pending so put_nowait doesn't block.
+                try:
+                    self._req_q.get_nowait()
+                except Exception:
+                    pass
+                try:
+                    self._req_q.put_nowait(None)
+                except Exception:
+                    pass
+            except Exception:
+                pass
+
+        proc = self._worker_proc
+        if proc is not None:
+            try:
+                proc.join(timeout=0.5)
+                if proc.is_alive():
+                    proc.terminate()
+                    proc.join(timeout=0.5)
+                if proc.is_alive():
+                    proc.kill()
+                    proc.join()
+            except Exception as e:
+                print(f"Error stopping thumbnail worker: {e}")
+
+        # Cancel feeder threads so any unflushed item doesn't raise BrokenPipeError.
+        for q in (self._req_q, self._rep_q):
+            if q is None:
+                continue
+            try:
+                q.cancel_join_thread()
+                q.close()
+            except Exception:
+                pass
+
+        self._worker_proc = None
+        self._req_q = None
+        self._rep_q = None
+
+    @staticmethod
+    def _worker_main(req_q, rep_q):
+        """Worker entry point: latest-wins payload, preempts between images."""
+        current = None
+        idx = 0
+        while True:
+            # Pick up new payload. Block briefly if idle, otherwise non-blocking
+            # so we can preempt mid-job.
+            payload = None
+            got_payload = False
+            try:
+                if current is None:
+                    payload = req_q.get(timeout=0.25)
+                else:
+                    payload = req_q.get_nowait()
+                got_payload = True
+            except queue_mod.Empty:
+                got_payload = False
+            except Exception:
+                # Queue closed / pipe broken — exit cleanly.
                 return
-            
-            self.last_mode_switch_time = current_time
-            
-            self.generate_thumbnails = generate_thumbnails
-            
-            self.clear_all_thumbnails()
-            
-            if not generate_thumbnails and self.selected_files:
-                self.update_thumbnails(self.selected_files)
-    
+
+            if got_payload:
+                if payload is None:
+                    return  # shutdown sentinel
+                if isinstance(payload, dict):
+                    current = payload
+                    idx = 0
+                else:
+                    continue
+
+            if current is None:
+                continue
+
+            paths = current.get('paths') or []
+            size = current.get('size', 140)
+            gen_id = current.get('generation', 0)
+
+            if idx >= len(paths):
+                current = None
+                continue
+
+            path = paths[idx]
+            idx += 1
+            data = _render_thumbnail(path, size)
+            try:
+                rep_q.put({'generation': gen_id, 'file_path': path, 'data': data})
+            except Exception:
+                return
+
+    # --- File list management -----------------------------------------------
+
+    def set_thumbnail_mode(self, generate_thumbnails, prev_thumbnail_mode=None):
+        """Public toggle: route to set_render_mode and clear placeholders.
+
+        Rendered cache survives the toggle so re-enabling is instant.
+        """
+        prev = prev_thumbnail_mode if prev_thumbnail_mode is not None else self.generate_thumbnails
+        if prev == generate_thumbnails:
+            return
+        self.clear_placeholder_thumbnails()
+        self.set_render_mode(generate_thumbnails)
+
     def update_thumbnails(self, file_paths):
         """Update the file list. Textures are created lazily during render."""
         self.selected_files = file_paths
-    
+        # New file list invalidates any in-flight worker results.
+        self._generation += 1
+
     def clear_thumbnails(self):
-        """Clear all thumbnails and free memory"""
-        textures_to_delete = list(self.thumbnails.values())
-        self.thumbnails.clear() 
-        
-        for texture in textures_to_delete:
-            if texture is not None:
-                try:
-                    texture.delete()
-                except Exception as e:
-                    print(f"Error deleting texture: {e}")
-    
+        """Defer-delete all rendered thumbnails."""
+        for tex in self.thumbnails.values():
+            if tex is not None:
+                self._deferred_delete.append(tex)
+        self.thumbnails.clear()
+
     def clear_placeholder_thumbnails(self):
-        """Clear all placeholder thumbnails and free memory"""
-        textures_to_delete = list(self.placeholder_textures.values())
-        self.placeholder_textures.clear()  
-        
-        for texture in textures_to_delete:
-            if texture is not None:
-                try:
-                    texture.delete()
-                except Exception as e:
-                    print(f"Error deleting placeholder texture: {e}")
-    
+        """Defer-delete all placeholder thumbnails."""
+        for tex in self.placeholder_textures.values():
+            if tex is not None:
+                self._deferred_delete.append(tex)
+        self.placeholder_textures.clear()
+
     def clear_all_thumbnails(self):
         """Clear both actual and placeholder thumbnails"""
         self.clear_thumbnails()
@@ -170,10 +351,8 @@ class ThumbnailWidget:
             if tex is not None:
                 self._deferred_delete.append(tex)
 
-    def get_pending_render_paths(self):
-        """Return visible file paths that still need a rendered thumbnail."""
-        return self._pending_render_paths
-    
+    # --- Rendering ----------------------------------------------------------
+
     def render_thumbnails(self, available_width, available_height):
         self._flush_deferred_deletes()
         self._frame_held_textures = []
@@ -210,11 +389,6 @@ class ThumbnailWidget:
         total_row_width = thumbnails_per_row * thumb_size + (thumbnails_per_row - 1) * spacing_x
         left_margin = grid_padding + max(0, (inner_width - total_row_width) // 2)
 
-        if not hasattr(self, 'last_selected_idx'):
-            self.last_selected_idx = None
-        if not hasattr(self, 'selected_indices'):
-            self.selected_indices = []
-
         text_line_height = imgui.get_text_line_height_with_spacing()
         row_height = thumb_size + spacing_y + text_line_height
         total_rows = math.ceil(n / thumbnails_per_row)
@@ -231,11 +405,9 @@ class ThumbnailWidget:
         first_render_idx = first_render_row * thumbnails_per_row
         last_render_idx = min(n, (last_render_row + 1) * thumbnails_per_row)
 
-        # Top spacer to maintain scroll position for rows above the render range
         if first_render_row > 0:
             imgui.dummy(available_width, first_render_row * row_height)
 
-        # Keyboard shortcuts are checked once per frame, outside the per-thumbnail loop
         ctrl_down = imgui.is_key_down(341) or imgui.is_key_down(345)
         shift_down = imgui.is_key_down(340) or imgui.is_key_down(344)
         a_pressed = imgui.is_key_pressed(65)
@@ -317,29 +489,78 @@ class ThumbnailWidget:
                     imgui.new_line()
                     imgui.dummy(0, spacing_y)
 
-        # Bottom spacer for rows below the render range
         remaining_rows = total_rows - 1 - last_render_row
         if remaining_rows > 0:
             imgui.dummy(available_width, remaining_rows * row_height)
 
+        # Always free off-screen textures to keep GPU memory bounded; the
+        # caches outlive render-mode toggles so this runs unconditionally.
         self._cleanup_offscreen_placeholders(rendered_files)
+        self._cleanup_offscreen_thumbnails(rendered_files)
 
+        # Schedule worker to render the visible/buffer set, viewport-first.
         if self.generate_thumbnails:
-            self._pending_render_paths = [fp for fp in rendered_files if fp not in self.thumbnails]
-            
-            self._cleanup_offscreen_thumbnails(rendered_files)
-        else:
-            self._pending_render_paths = []
-    
+            self._schedule_render_requests(
+                first_render_idx, last_render_idx,
+                first_visible_row, last_visible_row,
+                thumbnails_per_row,
+            )
+
+    def _schedule_render_requests(self, first_render_idx, last_render_idx,
+                                  first_visible_row, last_visible_row,
+                                  thumbnails_per_row):
+        """Build a center-out list of needed paths and post it to the worker slot."""
+        if self._req_q is None:
+            self._ensure_worker()
+            if self._req_q is None:
+                return
+
+        visible_first_idx = max(first_render_idx, first_visible_row * thumbnails_per_row)
+        visible_last_idx = min(last_render_idx, (last_visible_row + 1) * thumbnails_per_row)
+
+        ordered_indices = list(range(visible_first_idx, visible_last_idx))
+        above = list(range(visible_first_idx - 1, first_render_idx - 1, -1))
+        below = list(range(visible_last_idx, last_render_idx))
+        a = b = 0
+        while a < len(above) or b < len(below):
+            if b < len(below):
+                ordered_indices.append(below[b])
+                b += 1
+            if a < len(above):
+                ordered_indices.append(above[a])
+                a += 1
+
+        needed = [self.selected_files[i]
+                  for i in ordered_indices
+                  if self.selected_files[i] not in self.thumbnails]
+        if not needed:
+            return
+
+        payload = {
+            'generation': self._generation,
+            'paths': needed,
+            'size': self.thumbnail_size,
+        }
+        # Latest-wins: drain any stale slot, then put the new payload.
+        try:
+            self._req_q.get_nowait()
+        except Exception:
+            pass
+        try:
+            self._req_q.put_nowait(payload)
+        except Exception:
+            pass
+
+    # --- Selection / utilities ---------------------------------------------
+
     def get_thumbnail_count(self):
         """Get the number of thumbnails"""
         return len(self.selected_files)
-    
+
     def get_selected_files(self):
         """Get the list of selected files"""
         return self.selected_files.copy()
 
-    # Select All button
     def select_all(self):
         """Select all images"""
         self.selected_indices = list(range(len(self.selected_files)))
@@ -351,28 +572,30 @@ class ThumbnailWidget:
         elif self.last_selected_idx is not None:
             return [self.last_selected_idx]
         return []
-    
+
     def clear_selected(self):
         self.last_selected_idx = None
         self.selected_indices = []
-    
+
     def is_delete_pressed(self):
         """Check if delete was pressed and reset the flag"""
         if self.delete_pressed:
             self.delete_pressed = False
             return True
         return False
-    
+
     def update_thumbnail_from_data(self, file_path, thumbnail_data):
-        """Update a specific thumbnail with processed data from background processing"""
-        if thumbnail_data is not None:
-            texture = self._create_texture_from_data(thumbnail_data)
-            if texture is not None:
-                old = self.thumbnails.get(file_path)
-                if old is not None:
-                    self._deferred_delete.append(old)
-                self.thumbnails[file_path] = texture
-    
+        """Install a worker result as a rendered texture, deferring old texture deletion."""
+        if thumbnail_data is None:
+            return
+        texture = self._create_texture_from_data(thumbnail_data)
+        if texture is None:
+            return
+        old = self.thumbnails.get(file_path)
+        if old is not None:
+            self._deferred_delete.append(old)
+        self.thumbnails[file_path] = texture
+
     def _create_texture_from_data(self, thumbnail_data):
         """Create OpenGL texture from thumbnail data"""
         try:
@@ -386,84 +609,12 @@ class ThumbnailWidget:
             print(f"Error creating texture from thumbnail data: {e}")
             return None
 
-    @staticmethod
-    def process_thumbnails_background(queue, reply):
-        """Process thumbnails in background - static method called by multiprocessing."""
-        while True:
-            try:
-                request = queue.get(timeout=1.0)
-                if request is None or request.get('type') == 'shutdown':
-                    break
-                
-                if request['type'] == 'generate_thumbnails':
-                    file_paths = request['file_paths']
-                    thumbnail_size = request['thumbnail_size']
-                    
-                    for file_path in file_paths:
-                        try:
-                            thumbnail_data = None
-                            
-                            video_extensions = ['.mp4', '.avi', '.mov', '.mkv', '.wmv', '.flv', '.webm']
-                            file_ext = os.path.splitext(file_path)[1].lower()
-                            
-                            if file_ext in video_extensions:
-                                cap = cv2.VideoCapture(file_path)
-                                if cap.isOpened():
-                                    ret, frame = cap.read()
-                                    cap.release()
-                                    
-                                    if ret:
-                                        if len(frame.shape) == 3 and frame.shape[2] == 3:
-                                            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-                                        elif len(frame.shape) == 3 and frame.shape[2] == 4:
-                                            frame = cv2.cvtColor(frame, cv2.COLOR_BGRA2RGBA)
-                                        
-                                        height, width = frame.shape[:2]
-                                        max_dim = max(height, width)
-                                        canvas = np.zeros((max_dim, max_dim, frame.shape[2] if len(frame.shape) > 2 else 1), dtype=frame.dtype)
-                                        
-                                        y_offset = (max_dim - height) // 2
-                                        x_offset = (max_dim - width) // 2
-                                        canvas[y_offset:y_offset+height, x_offset:x_offset+width] = frame
-                                        
-                                        thumbnail_data = cv2.resize(canvas, (thumbnail_size, thumbnail_size), interpolation=cv2.INTER_AREA)
-                            else:
-                                utils = DatasetPreprocessingUtils()
-                                img = utils.load_images(file_path)
-
-                                height, width = img.shape[:2]
-                                max_dim = max(height, width)
-                                padding_colour = 26  
-                                canvas = np.full((max_dim, max_dim, img.shape[2] if len(img.shape) > 2 else 1), padding_colour, dtype=img.dtype)
-
-                                y_offset = (max_dim - height) // 2
-                                x_offset = (max_dim - width) // 2
-                                canvas[y_offset:y_offset+height, x_offset:x_offset+width] = img
-                                
-                                thumbnail_data = cv2.resize(canvas, (thumbnail_size, thumbnail_size), interpolation=cv2.INTER_AREA)
-                            
-                            reply.put({
-                                'type': 'thumbnail',
-                                'file_path': file_path,
-                                'thumbnail_data': thumbnail_data
-                            })
-                            
-                        except Exception as e:
-                            print(f"Error creating thumbnail for {file_path}: {e}")
-                            reply.put({
-                                'type': 'thumbnail',
-                                'file_path': file_path,
-                                'thumbnail_data': None
-                            })
-                    
-                    reply.put({'type': 'completed'})
-                
-            except:
-                continue  
+    # --- Cleanup ------------------------------------------------------------
 
     def cleanup(self):
-        """Clean up OpenGL textures and resources"""
+        """Tear down worker and free all textures."""
         try:
+            self.shutdown()
             self.generate_thumbnails = False
             self._flush_deferred_deletes()
             self._frame_held_textures = []
@@ -476,7 +627,7 @@ class ThumbnailWidget:
                     except Exception as e:
                         print(f"Error deleting thumbnail texture: {e}")
             self.thumbnails.clear()
-            
+
             for texture in self.placeholder_textures.values():
                 if texture is not None and hasattr(texture, 'delete') and callable(texture.delete):
                     try:
@@ -485,15 +636,15 @@ class ThumbnailWidget:
                     except Exception as e:
                         print(f"Error deleting placeholder texture: {e}")
             self.placeholder_textures.clear()
-            
+
             self.selected_files = []
             self.selected_indices = []
             self.last_selected_idx = None
-            
+
             gc.collect()
-            
+
         except Exception as e:
             print(f"Warning: Error during thumbnail widget cleanup: {e}")
 
     def __del__(self):
-        pass 
+        pass

--- a/widgets/thumbnail_widget.py
+++ b/widgets/thumbnail_widget.py
@@ -1,6 +1,7 @@
 import cv2
 import os
 import math
+import collections
 import queue as queue_mod
 import multiprocessing as mp
 import numpy as np
@@ -65,19 +66,21 @@ class ThumbnailWidget:
 
     def __init__(self):
         self.thumbnail_size = 140  # Determines quality of thumbnails (resolution)
-        self.thumbnails = {}  # Cache for rendered thumbnail textures
-        self.placeholder_textures = {}  # Cache for placeholder textures
+        self.thumbnails = {}  
+        self.placeholder_textures = {}  
         self.generate_thumbnails = False  # Show rendered thumbnails (when available) vs placeholders
         self.selected_files = []
         self.last_selected_idx = None
         self.selected_indices = []
         self.delete_pressed = False
 
-        # Texture lifetime helpers (deferred deletion + per-frame strong refs)
         self._deferred_delete = []
         self._frame_held_textures = []
 
-        # Background worker IPC for rendered thumbnails
+        # FIFO cache for rendered thumbnails outside the visible+buffer window.
+        self._cached_thumbnails = collections.OrderedDict()
+        self.max_cached_thumbnails = 1000
+
         self._req_q = None       # mp.Queue(maxsize=1) — latest-wins payload
         self._rep_q = None       # mp.Queue() — streamed results
         self._worker_proc = None
@@ -134,9 +137,19 @@ class ThumbnailWidget:
             return canvas
 
     def get_thumbnail(self, file_path):
-        """Return rendered texture if available + render mode on, else placeholder."""
-        if self.generate_thumbnails and file_path in self.thumbnails:
-            return self.thumbnails[file_path]
+        """Return rendered texture if available + render mode on, else placeholder.
+
+        Promotes a cached texture back into the active set when the path
+        re-enters the render window so subsequent demotions land it at the
+        tail of the FIFO again.
+        """
+        if self.generate_thumbnails:
+            if file_path in self.thumbnails:
+                return self.thumbnails[file_path]
+            cached = self._cached_thumbnails.pop(file_path, None)
+            if cached is not None:
+                self.thumbnails[file_path] = cached
+                return cached
         if file_path not in self.placeholder_textures:
             self.placeholder_textures[file_path] = self.create_placeholder_thumbnail(file_path)
         return self.placeholder_textures[file_path]
@@ -193,10 +206,8 @@ class ThumbnailWidget:
 
     def shutdown(self):
         """Tear down the worker process and queues without raising BrokenPipeError."""
-        # Send wake/exit sentinel so worker can exit cleanly if it's blocking on get().
         if self._req_q is not None:
             try:
-                # Drain anything pending so put_nowait doesn't block.
                 try:
                     self._req_q.get_nowait()
                 except Exception:
@@ -221,7 +232,6 @@ class ThumbnailWidget:
             except Exception as e:
                 print(f"Error stopping thumbnail worker: {e}")
 
-        # Cancel feeder threads so any unflushed item doesn't raise BrokenPipeError.
         for q in (self._req_q, self._rep_q):
             if q is None:
                 continue
@@ -241,8 +251,6 @@ class ThumbnailWidget:
         current = None
         idx = 0
         while True:
-            # Pick up new payload. Block briefly if idle, otherwise non-blocking
-            # so we can preempt mid-job.
             payload = None
             got_payload = False
             try:
@@ -254,12 +262,11 @@ class ThumbnailWidget:
             except queue_mod.Empty:
                 got_payload = False
             except Exception:
-                # Queue closed / pipe broken — exit cleanly.
                 return
 
             if got_payload:
                 if payload is None:
-                    return  # shutdown sentinel
+                    return 
                 if isinstance(payload, dict):
                     current = payload
                     idx = 0
@@ -301,8 +308,13 @@ class ThumbnailWidget:
     def update_thumbnails(self, file_paths):
         """Update the file list. Textures are created lazily during render."""
         self.selected_files = file_paths
-        # New file list invalidates any in-flight worker results.
         self._generation += 1
+        valid = set(file_paths)
+        stale = [fp for fp in self._cached_thumbnails if fp not in valid]
+        for fp in stale:
+            tex = self._cached_thumbnails.pop(fp)
+            if tex is not None:
+                self._deferred_delete.append(tex)
 
     def clear_thumbnails(self):
         """Defer-delete all rendered thumbnails."""
@@ -318,9 +330,17 @@ class ThumbnailWidget:
                 self._deferred_delete.append(tex)
         self.placeholder_textures.clear()
 
+    def clear_cached_thumbnails(self):
+        """Defer-delete all FIFO-cached offscreen thumbnails."""
+        for tex in self._cached_thumbnails.values():
+            if tex is not None:
+                self._deferred_delete.append(tex)
+        self._cached_thumbnails.clear()
+
     def clear_all_thumbnails(self):
-        """Clear both actual and placeholder thumbnails"""
+        """Clear actual, cached, and placeholder thumbnails"""
         self.clear_thumbnails()
+        self.clear_cached_thumbnails()
         self.clear_placeholder_thumbnails()
 
     def _flush_deferred_deletes(self):
@@ -342,14 +362,26 @@ class ThumbnailWidget:
             if tex is not None:
                 self._deferred_delete.append(tex)
 
-    def _cleanup_offscreen_thumbnails(self, visible_files):
-        """Free rendered thumbnail textures that are outside the visible + buffer range."""
+    def _demote_offscreen_thumbnails(self, visible_files):
+        """Move rendered thumbnails outside the render window into the FIFO cache,
+        evicting the oldest cached entries once the limit is exceeded."""
         visible_set = set(visible_files)
-        to_remove = [fp for fp in self.thumbnails if fp not in visible_set]
-        for fp in to_remove:
+        to_demote = [fp for fp in self.thumbnails if fp not in visible_set]
+        for fp in to_demote:
             tex = self.thumbnails.pop(fp)
-            if tex is not None:
-                self._deferred_delete.append(tex)
+            if tex is None:
+                continue
+
+            if fp in self._cached_thumbnails:
+                old = self._cached_thumbnails.pop(fp)
+                if old is not None and old is not tex:
+                    self._deferred_delete.append(old)
+            self._cached_thumbnails[fp] = tex
+
+        while len(self._cached_thumbnails) > self.max_cached_thumbnails:
+            _, evicted = self._cached_thumbnails.popitem(last=False)
+            if evicted is not None:
+                self._deferred_delete.append(evicted)
 
     # --- Rendering ----------------------------------------------------------
 
@@ -493,10 +525,8 @@ class ThumbnailWidget:
         if remaining_rows > 0:
             imgui.dummy(available_width, remaining_rows * row_height)
 
-        # Always free off-screen textures to keep GPU memory bounded; the
-        # caches outlive render-mode toggles so this runs unconditionally.
         self._cleanup_offscreen_placeholders(rendered_files)
-        self._cleanup_offscreen_thumbnails(rendered_files)
+        self._demote_offscreen_thumbnails(rendered_files)
 
         # Schedule worker to render the visible/buffer set, viewport-first.
         if self.generate_thumbnails:
@@ -627,6 +657,15 @@ class ThumbnailWidget:
                     except Exception as e:
                         print(f"Error deleting thumbnail texture: {e}")
             self.thumbnails.clear()
+
+            for texture in self._cached_thumbnails.values():
+                if texture is not None and hasattr(texture, 'delete') and callable(texture.delete):
+                    try:
+                        if texture.gl_id is not None:
+                            texture.delete()
+                    except Exception as e:
+                        print(f"Error deleting cached thumbnail texture: {e}")
+            self._cached_thumbnails.clear()
 
             for texture in self.placeholder_textures.values():
                 if texture is not None and hasattr(texture, 'delete') and callable(texture.delete):

--- a/widgets/thumbnail_widget.py
+++ b/widgets/thumbnail_widget.py
@@ -457,6 +457,7 @@ class ThumbnailWidget:
 
         first_render_idx = first_render_row * thumbnails_per_row
         last_render_idx = min(n, (last_render_row + 1) * thumbnails_per_row)
+        first_render_idx = min(first_render_idx, last_render_idx)
 
         if first_render_row > 0:
             imgui.dummy(available_width, first_render_row * row_height)
@@ -568,6 +569,8 @@ class ThumbnailWidget:
 
         visible_first_idx = max(first_render_idx, first_visible_row * thumbnails_per_row)
         visible_last_idx = min(last_render_idx, (last_visible_row + 1) * thumbnails_per_row)
+        visible_first_idx = min(max(visible_first_idx, first_render_idx), last_render_idx)
+        visible_last_idx = min(max(visible_last_idx, first_render_idx), last_render_idx)
 
         ordered_indices = list(range(visible_first_idx, visible_last_idx))
         above = list(range(visible_first_idx - 1, first_render_idx - 1, -1))
@@ -581,9 +584,10 @@ class ThumbnailWidget:
                 ordered_indices.append(above[a])
                 a += 1
 
+        n = len(self.selected_files)
         needed = [self.selected_files[i]
                   for i in ordered_indices
-                  if self.selected_files[i] not in self.thumbnails]
+                  if 0 <= i < n and self.selected_files[i] not in self.thumbnails]
         if not needed:
             return
 


### PR DESCRIPTION
## Summary

Reworked thumbnail rendering pipeline and added queue-based caching saving previously rendered thumbnails outside of the viewport range. Fixed previous unstable rendering when scrolling up and down aggressively.

## Type of change

- [ ] Feature
- [x] Fix
- [x] Other (perf)

## How was this tested?

- Ran uv run main.py
- Open preprocessing module and import images
- Select the render thumbnail option
- Scroll up and down all the way to the end, then back to initial cursor location
- Checks:
-Previously rendered thumbnails stays there. If cache exceeds size, check if thumbnail is deleted and re-rendered.
-See if aggressive scrolling crashes the app