### PR TITLE
fix: avoid vector mode to flip anim and stop label

### DIFF
--- a/widgets/latent_widget.py
+++ b/widgets/latent_widget.py
@@ -168,7 +168,7 @@ class LatentWidget:
             self.latent.next = torch.randn(self.latent.next.shape)
 
         imgui.same_line()
-        if imgui_utils.button(f"{modes[self.latent.update_mode]}##latent"):
+        if imgui_utils.button(f"{modes[(int(self.latent.update_mode) + 1) % len(modes)]}##latent"):
             self.latent.update_mode = (int(self.latent.update_mode) + 1) % len(modes)
         imgui.same_line()
         with imgui_utils.item_width(viz.app.button_w * 2 - viz.app.spacing * 2):


### PR DESCRIPTION
## Summary

Fixed Stop and Anim button labels on the visualizer incorrectly flipping when switching between seed and vector latent mode, causing the label to show the opposing action.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Other (docs, refactor, chore, ci, etc.)

## How was this tested?

- Run uv run main.py
- Open Autolume Live
- Toggle between seed and vector latent mode and check if anim and stop button label corresponds to its actual action

https://github.com/user-attachments/assets/8c3ccfef-6351-4fc5-adc5-1eda750429aa