### PR TITLE
fix: draw splash image without window padding and border

### DIFF
--- a/modules/autolume_live.py
+++ b/modules/autolume_live.py
@@ -131,10 +131,14 @@ class Autolume(imgui_window.ImguiWindow):
         if self.state == States.SPLASH:
             imgui.set_next_window_position(0, 0)
             imgui.set_next_window_size(self.content_width, self.content_height)
+            # No padding or border so the splash image fills the window edge to edge.
+            imgui.push_style_var(imgui.STYLE_WINDOW_PADDING, (0, 0))
+            imgui.push_style_var(imgui.STYLE_WINDOW_BORDERSIZE, 0)
             imgui.begin('##welcome', closable=False,
                         flags=(imgui.WINDOW_NO_TITLE_BAR | imgui.WINDOW_NO_RESIZE | imgui.WINDOW_NO_MOVE | imgui.WINDOW_NO_SCROLLBAR))
             imgui.image(self.splash_texture.gl_id, self.content_width, self.content_height)
             imgui.end()
+            imgui.pop_style_var(2)
             self.splash_delay -= 1
             if self.splash_delay <= 0:
                 self.set_visible_menu()
@@ -145,10 +149,14 @@ class Autolume(imgui_window.ImguiWindow):
         if self.state == States.WELCOME:
             imgui.set_next_window_position(0, 0)
             imgui.set_next_window_size(self.content_width, self.content_height)
+            # No padding or border so the splash image fills the window edge to edge.
+            imgui.push_style_var(imgui.STYLE_WINDOW_PADDING, (0, 0))
+            imgui.push_style_var(imgui.STYLE_WINDOW_BORDERSIZE, 0)
             imgui.begin('##welcome', closable=False,
                         flags=(imgui.WINDOW_NO_TITLE_BAR | imgui.WINDOW_NO_RESIZE | imgui.WINDOW_NO_MOVE| imgui.WINDOW_NO_SCROLLBAR))
             imgui.image(self.splash_texture.gl_id, self.content_width, self.content_height)
             imgui.end()
+            imgui.pop_style_var(2)
             self.state = States.SPLASH
             self.splash_delay = 30
 


### PR DESCRIPTION
## Summary

Fixes a small glitch with the splash screen border

## Type of change

- [x] Fix

## How was this tested?

`uv run main.py`

## Checklist

- [x] PR title follows Conventional Commits without a scope (`<type>: <subject>`)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Screenshots or a short clip are attached for UI changes

Splash screen before:

<img width="1065" height="613" alt="Screenshot 2026-06-12 at 13 50 14" src="https://github.com/user-attachments/assets/b0dc9971-6897-49fc-a038-fbe4f9f9bcf5" />
