### PR TITLE
feat: add centralized logging with daily rotation across all processes

### DIFF
--- a/audio/audio_stream.py
+++ b/audio/audio_stream.py
@@ -1,3 +1,4 @@
+import logging
 from utils.utils import Deque
 
 import pyaudio
@@ -5,6 +6,9 @@ import numpy as np
 import time
 from functools import partial
 
+
+
+logger = logging.getLogger(__name__)
 
 class AudioStreamError(Exception):
     """Base exception for audio stream failures."""
@@ -53,8 +57,7 @@ class AudioStream(object):
             stream_callback=partial(self.non_blocking_stream_read, self.callback)
         )
 
-        print("\n##################################################################################################")
-        print("\nDefaulted to using first working mic, Running on:")
+        logger.info("Defaulted to using first working mic")
         self.print_mic_info(self.device)
 
     def non_blocking_stream_read(self, func, in_data, frame_count, time_info, status):
@@ -71,12 +74,12 @@ class AudioStream(object):
 
         self.data_buffer = Deque(self.buffer_size, self.update_window_n_frames)
 
-        print("Starting live audio stream...")
+        logger.info("Starting live audio stream")
         self.stream.start_stream()
         self.stream_start_time = time.time()
 
     def terminate(self):
-        print("Sending stream termination command...")
+        logger.info("Stopping audio stream")
         self.stream.stop_stream()
         self.stream.close()
 
@@ -93,7 +96,7 @@ class AudioStream(object):
         if self.test_device(device, rate=default_rate):
             return default_rate
 
-        print("SOMETHING'S WRONG! I can't figure out a good sample-rate for DEVICE =>", device)
+        logger.warning("Could not determine a good sample rate for device %s", device)
         return default_rate
 
     def test_device(self, device, rate=None):
@@ -130,10 +133,10 @@ class AudioStream(object):
                 mics.append(device)
 
         if len(mics) == 0:
-            print("No working microphone devices found!")
+            logger.warning("No working microphone devices found")
             raise NoMicrophoneError("No working microphone devices found")
 
-        print("Found %d working microphone device(s): " % len(mics))
+        logger.info("Found %d working microphone device(s)", len(mics))
         for mic in mics:
             self.print_mic_info(mic)
 
@@ -141,6 +144,4 @@ class AudioStream(object):
 
     def print_mic_info(self, mic):
         mic_info = self.pa.get_device_info_by_index(mic)
-        print('\nMIC %s:' % (str(mic)))
-        for k, v in sorted(mic_info.items()):
-            print("%s: %s" % (k, v))
+        logger.debug('MIC %s: %s', mic, dict(sorted(mic_info.items())))

--- a/bending/tl.py
+++ b/bending/tl.py
@@ -1,3 +1,4 @@
+import logging
 from torch import nn
 from torch.nn import init
 from torch.nn import functional as F
@@ -15,13 +16,16 @@ torch.ops.load_library("bending/transforms/rotate/build/librotate.so")
 torch.ops.load_library("bending/transforms/translate/build/libtranslate.so")
 
 
+
+logger = logging.getLogger(__name__)
+
 class Erode(nn.Module):
     def __init__(self):
         super().__init__()
 
     def forward(self, x, params, indicies):
         if (not isinstance(params[0], int) or params[0] < 0):
-            print('Erosion parameter must be a positive integer')
+            logger.warning('Erosion parameter must be a positive integer')
             # raise ValueError
 
         x_array = list(torch.split(x, 1, 1))
@@ -40,7 +44,7 @@ class Dilate(nn.Module):
 
     def forward(self, x, params, indicies):
         if (not isinstance(params[0], int) or params[0] < 0):
-            print('Dilation parameter must be a positive integer')
+            logger.warning('Dilation parameter must be a positive integer')
             # raise ValueError
 
         x_array = list(torch.split(x, 1, 1))
@@ -78,14 +82,12 @@ class Resize(nn.Module):
 
     def forward(self, x, params, indicies):
         if not isinstance(params[0], float) or not isinstance(params[1], float):
-            print('Resize must have two parameters, which should be positive floats.')
+            logger.warning('Resize must have two parameters, which should be positive floats.')
             # raise ValueError
         x_array = list(torch.split(x, 1, 1))
         for i, dim in enumerate(x_array):
             d_ = torch.squeeze(dim)
-            print(d_.size())
             tf = torch.ops.my_ops.resize(d_, params[0], params[1])
-            print(tf.size())
             tf = torch.unsqueeze(torch.unsqueeze(tf, 0), 0)
             x_array[i] = tf
         return torch.cat(x_array, 1)
@@ -97,7 +99,7 @@ class Scale(nn.Module):
 
     def forward(self, x, params, indicies):
         if (not isinstance(params[0], float)):
-            print('Scale parameter should be a float.')
+            logger.warning('Scale parameter should be a float.')
             # raise ValueError
         x_array = list(torch.split(x, 1, 1))
         for i, dim in enumerate(x_array):
@@ -115,7 +117,7 @@ class Rotate(nn.Module):
 
     def forward(self, x, params, indicies):
         if (not isinstance(params[0], float) or params[0] < 0 or params[0] > 360):
-            print('Rotation parameter should be a float between 0 and 360 degrees.')
+            logger.warning('Rotation parameter should be a float between 0 and 360 degrees.')
             # raise ValueError
         x_array = list(torch.split(x, 1, 1))
         for i, dim in enumerate(x_array):
@@ -179,7 +181,7 @@ class BinaryThreshold(nn.Module):
 
     def forward(self, x, params, indicies):
         if (not isinstance(params[0], float) or params[0] < -1 or params[0] > 1):
-            print('Binary threshold parameter should be a float between -1 and 1.')
+            logger.warning('Binary threshold parameter should be a float between -1 and 1.')
             # raise ValueError
 
         x_array = list(torch.split(x, 1, 1))
@@ -200,7 +202,7 @@ class ScalarMultiply(nn.Module):
 
     def forward(self, x, params, indicies):
         if (not isinstance(params[0], float)):
-            print('Scalar multiply parameter should be a float')
+            logger.warning('Scalar multiply parameter should be a float')
             # raise ValueError
 
         x_array = list(torch.split(x, 1, 1))
@@ -284,7 +286,6 @@ class ManipulationLayer(nn.Module):
                 self.save_activations(input, transform_dict['index'], transform_dict['params'][0],
                                       transform_dict['params'][1])
             if transform_dict['layerID'] == self.layerID:
-                print("indices",transform_dict.get('indices', [0]))
                 out = self.layer_options[transform_dict['transformID']](out, transform_dict['params'],
                                                                         transform_dict.get('indices', [0]))
         return out

--- a/bending/transform_layers.py
+++ b/bending/transform_layers.py
@@ -1,3 +1,4 @@
+import logging
 import torch
 from torch import nn
 from torch.nn import init
@@ -8,6 +9,9 @@ import torchvision
 import random
 import os
 import kornia
+
+
+logger = logging.getLogger(__name__)
 
 class Sobel(nn.Module):
     def __init__(self):
@@ -25,7 +29,6 @@ class Canny(nn.Module): #find a way to make faster
         super().__init__()
     
     def forward(self, x, params, indices):
-        print(x.shape)
         if params[0]:
                 # raise ValueError
             _, tf = kornia.filters.canny(x.permute(1,0,2,3)[indices])
@@ -38,9 +41,7 @@ class Erode(nn.Module):
     
     def forward(self, x, params, indices):
         if(not isinstance(params[0], int) or params[0] < 0):
-            print('Erosion parameter must be a positive integer')
-            # raise ValueError
-        print(params)
+            logger.warning('Erosion parameter must be a positive integer')
         x[:, indices] = kornia.morphology.erosion(x[:, indices], torch.ones((params[0],params[0]), device=x.device).to(x.dtype), engine="convolution")
         return x
 
@@ -50,7 +51,7 @@ class Dilate(nn.Module):
     
     def forward(self, x, params, indices):
         if(not isinstance(params[0], int) or params[0] < 0):
-            print('Dilation parameter must be a positive integer')
+            logger.warning('Dilation parameter must be a positive integer')
             # raise ValueError
         x[:, indices] = kornia.morphology.dilation(x[:, indices], torch.ones((params[0],params[0]), device=x.device).to(x.dtype), engine="convolution")
         return x
@@ -129,7 +130,7 @@ class BinaryThreshold(nn.Module):
     
     def forward(self, x, params, indices):
         if(not isinstance(params[0], float) or params[0] < -1 or params[0] > 1):
-            print('Binary threshold parameter should be a float between -1 and 1.')
+            logger.warning('Binary threshold parameter should be a float between -1 and 1.')
             # raise ValueError
         x[:, indices] = (x[:, indices] > params[0]).to(x.dtype)
         return x
@@ -140,7 +141,7 @@ class ScalarMultiply(nn.Module):
     
     def forward(self, x, params, indices):
         if(not isinstance(params[0], float)):
-            print('Scalar multiply parameter should be a float')
+            logger.warning('Scalar multiply parameter should be a float')
             # raise ValueError
         x[:, indices] *= params[0]
         return x

--- a/ganspace/estimators.py
+++ b/ganspace/estimators.py
@@ -8,6 +8,7 @@
 # OF ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+import logging
 from sklearn.decomposition import FastICA, PCA, IncrementalPCA, MiniBatchSparsePCA, SparsePCA, KernelPCA
 import fbpca
 import numpy as np
@@ -16,6 +17,9 @@ from types import SimpleNamespace
 
 
 # ICA
+
+logger = logging.getLogger(__name__)
+
 class ICAEstimator():
     def __init__(self, n_components):
         self.n_components = n_components
@@ -74,7 +78,7 @@ class IPCAEstimator():
                 self.transformer.n_samples_seen_.astype(np.int64)  # avoid overflow
             return True
         except ValueError as e:
-            print(f'\nIPCA error:', e)
+            logger.error('IPCA error: %s', e)
             return False
 
     def get_components(self):
@@ -112,7 +116,7 @@ class PCAEstimator():
         dotps = [np.dot(*self.transformer.components_[[i, j]])
                  for (i, j) in itertools.combinations(range(self.n_components), 2)]
         if not np.allclose(dotps, 0, atol=1e-4):
-            print('IPCA components not orghogonal, max dot', np.abs(dotps).max())
+            logger.warning('IPCA components not orthogonal, max dot %s', np.abs(dotps).max())
 
         self.transformer.mean_ = X.mean(axis=0, keepdims=True)
 
@@ -155,7 +159,7 @@ class FacebookPCAEstimator():
         dotps = [np.dot(*self.transformer.components_[[i, j]])
                  for (i, j) in itertools.combinations(range(self.n_components), 2)]
         if not np.allclose(dotps, 0, atol=1e-4):
-            print('FBPCA components not orghogonal, max dot', np.abs(dotps).max())
+            logger.warning('FBPCA components not orthogonal, max dot %s', np.abs(dotps).max())
 
         self.transformer.mean_ = X.mean(axis=0, keepdims=True)
 
@@ -203,7 +207,7 @@ class SPCAEstimator():
         dotps = [np.dot(*self.transformer.components_[[i, j]])
                  for (i, j) in itertools.combinations(range(self.n_components), 2)]
         if not np.allclose(dotps, 0, atol=1e-4):
-            print('SPCA components not orghogonal, max dot', np.abs(dotps).max())
+            logger.warning('SPCA components not orthogonal, max dot %s', np.abs(dotps).max())
 
     def get_components(self):
         var_ratio = self.stdev ** 2 / self.total_var

--- a/ganspace/extract_pca.py
+++ b/ganspace/extract_pca.py
@@ -1,3 +1,4 @@
+import logging
 import datetime
 
 import torch
@@ -17,6 +18,9 @@ def sample_latent(n_latents, model, device, c=None, project=False):
         latent = model.mapping(latent, c)[:, 0]
     return latent
 
+logger = logging.getLogger(__name__)
+
+
 def get_max_batch_size(model, device):
     if torch.device(device).type != 'cuda':
         # CUDA memory statistics are unavailable; use the default cap.
@@ -33,7 +37,7 @@ def get_max_batch_size(model, device):
         maxmem = torch.cuda.max_memory_allocated(device)
         del z
         if maxmem > 0.5*total_mem:
-            print('Batch size {:d}: memory usage {:.0f}MB'.format(i, maxmem / 1e6))
+            logger.debug('Batch size %d: memory usage %.0fMB', i, maxmem / 1e6)
             return i
     return B_max
 
@@ -46,10 +50,10 @@ def fit(queue, reply):
 
     sample_shape = model.w_dim
     sample_dims = np.prod(sample_shape)
-    print('Feature shape:', sample_shape, sample_dims)
+    logger.debug('Feature shape: %s %s', sample_shape, sample_dims)
     input_shape = model.z_dim
     input_dims = np.prod(input_shape)
-    print('Input shape:', input_shape, input_dims)
+    logger.debug('Input shape: %s %s', input_shape, input_dims)
     reply.put(["Setting up estimator", (None, None), False])
     transformer = setup_estimator(name, num_features, alpha)
     reply.put(["Estimating Batch Size", (None, None), False])
@@ -62,8 +66,8 @@ def fit(queue, reply):
     feat_size_bytes = sample_dims * np.dtype('float64').itemsize
     N_limit_RAM = np.floor_divide(target_bytes, feat_size_bytes)
     if not transformer.batch_support and N > N_limit_RAM:
-        print('WARNING: estimator does not support batching, ' \
-              'given config will use {:.1f} GB memory.'.format(feat_size_bytes / 1_000_000_000 * N))
+        logger.warning('Estimator does not support batching, '
+                       'given config will use %.1f GB memory.', feat_size_bytes / 1_000_000_000 * N)
     reply.put(['B={}, N={}, dims={}, N/dims={:.1f}'.format(B, N, sample_dims, N / sample_dims), (None, None), False])
 
 

--- a/main.py
+++ b/main.py
@@ -24,9 +24,6 @@ if IS_FROZEN:
             os.environ.setdefault("PYGLFW_LIBRARY", _glfw_cand)
             break
 
-import torch
-
-from modules.autolume_live import Autolume
 from utils.user_data import ensure_data_path
 
 
@@ -53,6 +50,8 @@ def main():
     # feature writes to it. Category subfolders are still created lazily.
     ensure_data_path()
 
+    from modules.autolume_live import Autolume
+
     app = Autolume()
 
     while not app.should_close():
@@ -62,9 +61,30 @@ def main():
 
 if __name__ == "__main__":
     multiprocessing.freeze_support()
-    torch.backends.cudnn.benchmark = True
-    torch.backends.cuda.matmul.allow_tf32 = True
-    torch.backends.cudnn.allow_tf32 = True
-    torch.set_grad_enabled(False)
     multiprocessing.set_start_method("spawn", force=True)
-    main()
+
+    from utils.app_logging import setup_main_logging, shutdown_logging
+    setup_main_logging()
+
+    import logging
+    logger = logging.getLogger("autolume")
+
+    try:
+        # Imported here (not at module level) so a failure in the heavy
+        # dependency stack is captured by the log instead of vanishing in
+        # windowed frozen builds.
+        import torch
+
+        torch.backends.cudnn.benchmark = True
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+        torch.set_grad_enabled(False)
+
+        main()
+    except SystemExit:
+        raise
+    except BaseException:
+        logger.critical("Fatal error", exc_info=True)
+        raise
+    finally:
+        shutdown_logging()

--- a/modules/autolume_live.py
+++ b/modules/autolume_live.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 
@@ -9,6 +10,9 @@ import gc
 from utils.gui_utils import imgui_window, gl_utils
 from utils.resource_paths import get_version, resource_path
 from enum import IntEnum
+
+logger = logging.getLogger(__name__)
+
 class States(IntEnum):
     ERROR = -2
     CLOSE = -1
@@ -78,7 +82,7 @@ class Autolume(imgui_window.ImguiWindow):
 
     def open_menu(self):
         from modules.menu import Menu
-        print("opening Menu")
+        logger.info("Opening menu")
         # Initialize window.
         self.menu = Menu(self)
 
@@ -100,7 +104,7 @@ class Autolume(imgui_window.ImguiWindow):
 
     def set_visible_menu(self):
         from modules.menu import Menu
-        print("setting visible menu ------------------------")
+        logger.info("Returning to menu")
         self.state = States.MENU
         self.set_fps_limit(self.DEFAULT_FPS_LIMIT)
         if self.viz is not None:

--- a/modules/compress_module.py
+++ b/modules/compress_module.py
@@ -1,3 +1,5 @@
+import logging
+
 import imgui
 
 import dnnlib
@@ -14,6 +16,9 @@ ada_pipes = ['blit', 'geom', 'color', 'filter', 'noise', 'cutout', 'bg', 'bgc', 
 diffaug_pipes = ['color, translation, cutoff', 'color, translation', 'color, cutoff', 'color',
                  'translation', 'cutoff', 'translation', 'cutoff']
 sizes = ["64", "128", "256", "512", "1024"]
+
+logger = logging.getLogger(__name__)
+
 class CompressModule:
     def __init__(self, menu):
         self.img_factor = 4
@@ -64,8 +69,7 @@ class CompressModule:
         _, self.noise_prob = imgui.input_float("Noise Probability", self.noise_prob)
 
         if imgui_utils.button('Compress', enabled=len(self.compress_pkl) > 0, width=-1):
-            print("Compressing")
-            print(self.compress_pkl)
+            logger.info("Compressing model %s", self.compress_pkl)
             prune_main(self.compress_pkl, self.save_path, n_samples=self.n_samples, batch_size=self.batch_size_compress,
                        noise_prob=self.noise_prob, remove_ratio=self.compression_factor)
 

--- a/modules/network_mixing.py
+++ b/modules/network_mixing.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 
 import imgui
 import numpy as np
@@ -16,6 +17,9 @@ import os
 import re
 import pandas as pd
 from widgets.help_icon_widget import HelpIconWidget
+
+logger = logging.getLogger(__name__)
+
 
 def _locate_results(pattern):
     return pattern
@@ -56,7 +60,6 @@ class MixingModule:
         self.model_dropdowns = {m: ModelDropdownButton(menu.model_downloader, label='Browse...') for m in (1, 2)}
 
     def load_pkl(self, pkl, m, ignore_errors=False):
-        print("loading---------")
         menu = self.menu
         try:
             resolved = self.resolve_pkl(pkl)
@@ -66,7 +69,7 @@ class MixingModule:
             else:
                 self.model2 = resolved
         except Exception as e:
-            print("error", e)
+            logger.error("Failed to resolve network pickle %s: %s", pkl, e)
             self.cur_pkl = None
             self.user_pkl = pkl
             if pkl != '':
@@ -86,19 +89,17 @@ class MixingModule:
                     flags=imgui.WINDOW_NO_RESIZE | imgui.WINDOW_NO_MOVE | imgui.WINDOW_NO_COLLAPSE)
         imgui.text(f"Loading model...{name}")
         imgui.end()
-        print("loading model starting get function, should be showing a window", name)
         net, data = self.get_network(resolved, 'G_ema')
 
         # if net is an exception then show a popup with the error
         if isinstance(net, Exception):
             imgui.open_popup('Error##pkl')
-            print("error", net)
+            logger.error("Failed to load network pickle: %s", net)
             if imgui.begin_popup('Error##pkl'):
                 imgui.text(f'Failed to load network pickle because of the following error: {net}')
                 imgui.end_popup()
             return
 
-        print("Net is:", net)
         if m == 1:
             self.pkl1 = net
             self.data1 = data
@@ -137,7 +138,7 @@ class MixingModule:
     def get_network(self, pkl, key, **tweak_kwargs):
         data = self._pkl_data.get(pkl, None)
         if data is None:
-            print(f'Loading "{pkl}"... ', end='', flush=True)
+            logger.info('Loading network pickle "%s"', pkl)
             try:
                 with dnnlib.util.open_url(pkl, verbose=False) as f:
                     data = legacy.load_network_pkl(f, custom=True)
@@ -421,12 +422,10 @@ class MixingModule:
         dict_dest = model_out.state_dict()
         # depending on what model is used in the first entry extract the mapping layers from the corresponding model and copy them to the new model
         if self.combined_layers[0] == "A":
-            print("MAPPING A")
             mapping_names = extract_mapping_names(self.pkl1)
             for name in mapping_names:
                 dict_dest[name] = self.pkl1.state_dict()[name]
         elif self.combined_layers[0] == "B":
-            print("MAPPING B")
             mapping_names = extract_mapping_names(self.pkl2)
             for name in mapping_names:
                 dict_dest[name] = self.pkl2.state_dict()[name]
@@ -434,16 +433,14 @@ class MixingModule:
         # iterate over self.combine_channels and copy weights from self.pkl1 or self.pkl2 depending on the value
         for i, entry in enumerate(self.combined_layers):
             if entry == "A":
-                print("A")
                 dict_dest[layer1[i]] = self.pkl1.state_dict()[layer1[i]]
             elif entry == "B":
-                print("B")
                 dict_dest[layer2[i]] = self.pkl2.state_dict()[layer2[i]]
 
         model_out_dict = model_out.state_dict()
         model_out_dict.update(dict_dest)
         model_out.load_state_dict(dict_dest)
-        print("Saving model...")
+        logger.info("Saving mixed model %s", self.output_name)
         data = dict([('G', None), ('D', None), ('G_ema', None)])
 
         with open(os.path.join(ensure_models_dir(), self.output_name + ".pkl"), 'wb') as f:

--- a/modules/network_surgery.py
+++ b/modules/network_surgery.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 
 import imgui
 
@@ -13,6 +14,8 @@ import pickle
 import glob
 import os
 import re
+
+logger = logging.getLogger(__name__)
 
 def _locate_results(pattern):
     return pattern
@@ -51,7 +54,6 @@ class SurgeryModule:
 
 
     def load_pkl(self, pkl, m,ignore_errors=False):
-        print("loading---------")
         menu = self.menu
         try:
             resolved = self.resolve_pkl(pkl)
@@ -61,7 +63,7 @@ class SurgeryModule:
             else:
                 self.model2 = resolved
         except Exception as e:
-            print("error", e)
+            logger.error("Failed to resolve network pickle %s: %s", pkl, e)
             self.cur_pkl = None
             self.user_pkl = pkl
             if pkl != '':
@@ -81,19 +83,17 @@ class SurgeryModule:
                     flags=imgui.WINDOW_NO_RESIZE | imgui.WINDOW_NO_MOVE | imgui.WINDOW_NO_COLLAPSE)
         imgui.text(f"Loading model...{name}")
         imgui.end()
-        print("loading model starting get function, should be showing a window", name)
         net, data = self.get_network(resolved, 'G_ema')
 
         # if net is an exception then show a popup with the error
         if isinstance(net, Exception):
             imgui.open_popup('Error##pkl')
-            print("error", net)
+            logger.error("Failed to load network pickle: %s", net)
             if imgui.begin_popup('Error##pkl'):
                 imgui.text(f'Failed to load network pickle because of the following error: {net}')
                 imgui.end_popup()
             return
 
-        print("Net is:", net)
         if m == 1:
             self.pkl1 = net
             self.data1 = data
@@ -133,7 +133,7 @@ class SurgeryModule:
     def get_network(self, pkl, key, **tweak_kwargs):
         data = self._pkl_data.get(pkl, None)
         if data is None:
-            print(f'Loading "{pkl}"... ', end='', flush=True)
+            logger.info('Loading network pickle "%s"', pkl)
             try:
                 with dnnlib.util.open_url(pkl, verbose=False) as f:
                     data = legacy.load_network_pkl(f, custom=True)
@@ -244,30 +244,25 @@ class SurgeryModule:
         dict_dest = model_out.state_dict()
         # depending on what model is used in the first entry extract the mapping layers from the corresponding model and copy them to the new model
         if self.combined_layers[0] == "Model A":
-            print("MAPPING A")
             mapping_names = extract_mapping_names(self.pkl1)
             for name in mapping_names:
                 dict_dest[name] = self.pkl1.state_dict()[name]
         elif self.combined_layers[0] == "Model B":
-            print("MAPPING B")
             mapping_names = extract_mapping_names(self.pkl2)
             for name in mapping_names:
                 dict_dest[name] = self.pkl2.state_dict()[name]
 
         # iterate over self.combine_channels and copy weights from self.pkl1 or self.pkl2 depending on the value
-        print(self.combined_layers)
         for i, entry in enumerate(self.combined_layers):
             if entry == "Model A":
-                print("A")
                 dict_dest[layer1[i]] = self.pkl1.state_dict()[layer1[i]]
             elif entry == "Model B":
-                print("B")
                 dict_dest[layer2[i]] = self.pkl2.state_dict()[layer2[i]]
 
         model_out_dict = model_out.state_dict()
         model_out_dict.update(dict_dest)
         model_out.load_state_dict(dict_dest)
-        print("Saving model...")
+        logger.info("Saving combined model %s", self.output_name)
         data = dict([('G', None), ('D', None), ('G_ema', None)])
 
         with open(os.path.join(ensure_models_dir(), self.output_name), 'wb') as f:
@@ -332,8 +327,6 @@ class SurgeryModule:
                     imgui.same_line()
                     if imgui.button("<-##Resolutions{}".format(resolution)) and l2:
                         self.combined_layers[i] = "Model B"
-
-                        print("CLICKING MODEL B")
                         for j in range(i + 1, len(self.combined_layers)):
                             if layer2[j]:
                                 res = int(re.search(r'\d+', layer2[j]).group())

--- a/modules/pca_module.py
+++ b/modules/pca_module.py
@@ -11,6 +11,7 @@ import pandas as pd
 import dnnlib
 from torch_utils import legacy
 from utils import device_utils
+from utils.app_logging import LoggedProcess
 from utils.gui_utils import imgui_utils
 from ganspace.extract_pca import fit
 from widgets.model_download_widget import ModelDropdownButton
@@ -43,8 +44,8 @@ class PCA_Module:
         self.queue = mp.Queue()
         self.reply = mp.Queue()
         self.message = ""
-        self.pca_process = mp.Process(target=fit, args=(self.queue, self.reply),
-                                      daemon=True)
+        self.pca_process = LoggedProcess(target=fit, args=(self.queue, self.reply),
+                                         daemon=True, name='ganspace-pca')
 
         self.save_path_browser = NativeBrowserWidget()
         self.X_comp, self.Z_comp = None, None
@@ -136,8 +137,6 @@ class PCA_Module:
             directory_path = self.save_path_browser.select_directory("Select Save Directory", initial_dir=self.save_path)
             if directory_path:
                 self.save_path = directory_path.replace('\\', '/')
-            else:
-                print("No save path selected")
 
         if imgui_utils.button("Get Salient Features", width=imgui.get_content_region_available_width(), enabled=self.G is not None):
             imgui.open_popup("PCA-popup")

--- a/modules/preprocessing_module.py
+++ b/modules/preprocessing_module.py
@@ -1,9 +1,11 @@
+import logging
 from pathlib import Path
 import pandas as pd
 import imgui
 from utils.gui_utils import imgui_utils
 import multiprocessing as mp
 
+from utils.app_logging import LoggedProcess
 from widgets.native_browser_widget import NativeBrowserWidget
 from widgets.thumbnail_widget import ThumbnailWidget
 from widgets.image_preview_widget import ImagePreviewWidget
@@ -13,6 +15,8 @@ from utils.dataset_preprocessing_utils import DatasetPreprocessingUtils
 
 resize_mode = ['stretch','center crop']
 padding_color = ['black', 'white', 'bleeding']
+
+logger = logging.getLogger(__name__)
 
 class DataPreprocessing:
     """Data Preprocessing UI"""
@@ -54,7 +58,7 @@ class DataPreprocessing:
         self.processing_queue = mp.Queue()
         self.processing_reply = mp.Queue()
         self.cancel_processing = False
-        self.processing_process = mp.Process(target=DatasetPreprocessingUtils.create_training_dataset, args=(self.processing_queue, self.processing_reply))
+        self.processing_process = LoggedProcess(target=DatasetPreprocessingUtils.create_training_dataset, args=(self.processing_queue, self.processing_reply), name='dataset-build')
         
         # Processing popup control
         self.is_processing_dataset = False
@@ -221,9 +225,10 @@ class DataPreprocessing:
                     self.is_processing_video = True
                     self.loading_widget.show_simple("Extracting frames...", show_progress=True)
                     self.loading_widget.update_progress(0, len(self.selected_video_files))
-                    mp.Process(
+                    LoggedProcess(
                         target=DatasetPreprocessingUtils.extract_videos,
-                        args=(self.selected_video_files, self.fps, self.video_extraction_queue, self.video_extraction_reply)
+                        args=(self.selected_video_files, self.fps, self.video_extraction_queue, self.video_extraction_reply),
+                        name='video-extract'
                     ).start()
             else:
                 self.loading_widget.render()
@@ -472,14 +477,12 @@ class DataPreprocessing:
             directory_path = self.data_browser.select_directory("Select Save Path", initial_dir=self.save_path)
             if directory_path:
                 self.save_path = directory_path.replace('\\', '/')
-            else:
-                print("No save path selected")
         
         imgui.spacing()
         
         if imgui.button("Process & Save Data", width=parameter_column_width, height=30):
             if not self.imported_files:
-                print("No images to process.")
+                logger.warning("No images to process")
             else:
                 self.settings.images = self.imported_files
 
@@ -872,9 +875,10 @@ class DataPreprocessing:
 
         self.processing_queue.put(self.settings)
         
-        self.processing_process = mp.Process(
+        self.processing_process = LoggedProcess(
             target=DatasetPreprocessingUtils.create_training_dataset,
-            args=(self.processing_queue, self.processing_reply))
+            args=(self.processing_queue, self.processing_reply),
+            name='dataset-build')
         self.processing_process.start()
     # ------------------------------
 
@@ -898,7 +902,7 @@ class DataPreprocessing:
                 self.help_icon.cleanup()
                 
         except Exception as e:
-            print(f"Warning: Error during cleanup: {e}")
+            logger.warning("Error during cleanup: %s", e)
 
     def reset_progress_variables(self):
         """Reset progress tracking variables to default values"""

--- a/modules/projection_module.py
+++ b/modules/projection_module.py
@@ -7,6 +7,7 @@ import torch
 from PIL import ImageFilter
 from PIL.Image import Image
 
+from utils.app_logging import LoggedProcess
 from utils.gui_utils import imgui_utils, gl_utils
 import multiprocessing as mp
 
@@ -50,8 +51,8 @@ class ProjectionModule:
         self.done_projecting = False
         self.target_image = None
         self.target_texture = None
-        self.projection_process = mp.Process(target=run_projection, args=(self.queue, self.reply),
-                                       daemon=True)
+        self.projection_process = LoggedProcess(target=run_projection, args=(self.queue, self.reply),
+                                                daemon=True, name='projection')
         self.projected_texture = None
 
         self.model_dropdown = ModelDropdownButton(menu.model_downloader)
@@ -117,9 +118,6 @@ class ProjectionModule:
             save_path = self.browser.select_directory("Select Save Directory", initial_dir=self.outdir)
             if save_path:
                 self.outdir = str(save_path)
-                print(self.outdir)
-            else:
-                print("No path selected")
 
         _changed, self.save_video = imgui.checkbox('Save Video##save_video', self.save_video)
         
@@ -162,8 +160,8 @@ class ProjectionModule:
             self.queue = mp.Queue()
             self.reply = mp.Queue()
 
-            self.projection_process = mp.Process(target=run_projection, args=(self.queue, self.reply),
-                                                 daemon=True)
+            self.projection_process = LoggedProcess(target=run_projection, args=(self.queue, self.reply),
+                                                    daemon=True, name='projection')
             self.projection_process.start()
             self.queue.put([self.network_path, self.target_fname[0] if self.target_fname != "" else None, self.target_text if self.target_text != "" else None, self.initial_latent, self.outdir, self.save_video, self.seed, self.lr, self.steps, self.use_vgg, self.use_clip, self.use_pixel, self.use_penalty, self.use_center, self.use_kmeans])
 

--- a/modules/renderloop.py
+++ b/modules/renderloop.py
@@ -4,6 +4,7 @@ import torch
 
 import dnnlib
 from utils import device_utils
+from utils.app_logging import LoggedProcess
 from widgets import renderer
 
 def compare_args(args, cur_args):
@@ -35,8 +36,8 @@ class AsyncRenderer:
         self._cur_stamp     = 0
         self._args_queue = multiprocessing.Queue()
         self._result_queue = multiprocessing.Queue()
-        self._process = multiprocessing.Process(target=self._process_fn, args=(self._args_queue, self._result_queue),
-                                                daemon=True)
+        self._process = LoggedProcess(target=self._process_fn, args=(self._args_queue, self._result_queue),
+                                      daemon=True, name='renderer')
         self._process.start()
 
     def close(self):

--- a/modules/super_res_module.py
+++ b/modules/super_res_module.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import threading
 import time
@@ -10,6 +11,7 @@ import torchvision.transforms.functional as F
 import numpy as np
 
 from utils import device_utils
+from utils.app_logging import LoggedProcess
 from utils.device_utils import get_device
 from utils.gui_utils import imgui_utils
 from super_res.super_res import main as super_res_main, load_model, get_resolution, check_width_height, get_audio, Reader, Writer, run_super_res, sr_weight_path, ensure_sr_weight
@@ -26,6 +28,8 @@ import pandas as pd
 args = EasyDict(result_path="", input_path=[""], model_type="Balance",
                 outscale=3, width=4096, height=4096, sharpen_scale=1, scale_mode=0)
 scale_factor = ['1', '2', '3', '4', '5', '6', '7', '8']
+
+logger = logging.getLogger(__name__)
 
 
 class SuperResModule:
@@ -153,7 +157,6 @@ class SuperResModule:
             files = self.browser.select_media_files(initial_dir=self.input_path[0] if self.input_path else "")
             if files:
                 self.input_path = [str(f) for f in files]
-                print(self.input_path)
 
         # Result path
         imgui.text("Save Path")
@@ -165,8 +168,6 @@ class SuperResModule:
             directory_path = self.browser.select_directory("Select Save Directory", initial_dir=self.result_path)
             if directory_path:
                 self.result_path = directory_path.replace('\\', '/')
-            else:
-                print("No save path selected")
         self.models = ['Quality','Balance','Fast']
         if len(self.models) > 0:
             # Model selection
@@ -181,8 +182,6 @@ class SuperResModule:
         imgui.same_line()
         with imgui_utils.item_width(input_width):
             clicked, self.scale_mode = imgui.combo("##scale_mode", self.scale_mode, ["Custom", "Scale"])
-        if clicked:
-            print(self.scale_mode)
 
         # Scale factor or custom resolution
         if self.scale_mode:
@@ -212,7 +211,6 @@ class SuperResModule:
 
         try:
             if imgui.button("Super Resolution", width=imgui.get_content_region_available_width()) and not self.running and not self.downloading:
-                print("Super Resolution")
                 args.result_path = self.result_path
                 args.input_path = self.input_path
                 args.model_type = self.model_type
@@ -224,15 +222,16 @@ class SuperResModule:
                 self.args = args
                 if os.path.exists(sr_weight_path(self.model_type)):
                     self.running = True
-                    print("Starting Super Resolution")
+                    logger.info("Starting super resolution: input=%s output=%s model=%s",
+                                self.input_path, self.result_path, self.model_type)
                     self.start_super_res()
                     imgui.open_popup("Super Resolution")
                 else:
                     self._begin_download(self.model_type)
                     imgui.open_popup("Downloading Model")
 
-        except Exception as e:
-            print("SRR ERROR", e)
+        except Exception:
+            logger.exception("Super resolution failed to start")
 
         if imgui.begin_popup_modal("Downloading Model", flags=imgui.WINDOW_NO_SCROLLBAR | imgui.WINDOW_ALWAYS_AUTO_RESIZE)[0]:
             self._display_download()
@@ -335,6 +334,6 @@ class SuperResModule:
         # Run upscaling in a separate process so it gets the GPU at full speed and the UI stays responsive
         self.queue = mp.Queue()
         self.reply = mp.Queue()
-        self.sr_process = mp.Process(target=run_super_res, args=(self.queue, self.reply), daemon=True)
+        self.sr_process = LoggedProcess(target=run_super_res, args=(self.queue, self.reply), daemon=True, name='super-res')
         self.sr_process.start()
         self.queue.put(self.args)

--- a/modules/training_module.py
+++ b/modules/training_module.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from re import S
 import zipfile
@@ -7,6 +8,7 @@ import multiprocessing as mp
 import psutil
 
 import dnnlib
+from utils.app_logging import LoggedProcess
 from utils.gui_utils import imgui_utils
 from train import main as train_main
 from widgets.native_browser_widget import NativeBrowserWidget
@@ -28,6 +30,8 @@ configs = ['auto', 'stylegan2', 'paper256', 'paper512', 'paper1024', 'cifar']
 resize_mode = ['stretch','center crop']
 MBSTD_GROUP = 2
 BATCH_SIZE_CHOICES = [MBSTD_GROUP * x for x in range(1, 33)]
+
+logger = logging.getLogger(__name__)
 
 class TrainingModule:
     def __init__(self, menu):
@@ -62,7 +66,7 @@ class TrainingModule:
         self.reply = mp.Queue()
         self.message = ""
         self.done = False
-        self.training_process = mp.Process(target=train_main, args=(self.queue, self.reply), name='TrainingProcess')
+        self.training_process = LoggedProcess(target=train_main, args=(self.queue, self.reply), name='training')
         self.found_video = False
         self._zipfile = None
         self.gamma = 10
@@ -142,7 +146,7 @@ class TrainingModule:
 
             # avoid re-printing stats lines
             if not self.message.strip().startswith('tick '):
-                print(self.message)
+                logger.debug("Training update: %s", self.message)
 
         # Create fixed regions to seperate training and preprocessing regions.
         # Max 94% height, or scroll bar would show up
@@ -202,15 +206,8 @@ class TrainingModule:
                         self.preprocessing_data_path = directory_path
                         self.data_path_has_videos = has_videos  
                         self.video_files_list = video_files  
-                        print(f"Data path selected: {self.preprocessing_data_path}")
-                        if has_videos:
-                            print(f"Found {len(video_files)} video files in directory")
-                            for video in video_files:
-                                print(f"  - {video}")
-                        else:
-                            print("No video files found in directory")
-                    else:
-                        print("No data path selected")
+                        logger.debug("Preprocessing data path selected: %s (%d videos)",
+                                     self.preprocessing_data_path, len(video_files))
 
                 imgui.spacing()
                 
@@ -278,14 +275,12 @@ class TrainingModule:
                     directory_path = self.preprocessing_save_browser.select_directory("Select Save Path", initial_dir=self.preprocessing_save_path)
                     if directory_path:
                         self.preprocessing_save_path = directory_path
-                    else:
-                        print("No save path selected")
 
                 imgui.spacing()
 
                 if imgui.button("Process & Save Data", width=-3):
                     if not self.preprocessing_save_path or not self.preprocessing_folder_name:
-                        print("Please specify both parent directory and folder name")
+                        logger.warning("Dataset creation needs both a parent directory and a folder name")
                     else:
                         self.create_preprocessing_dataset()
         imgui.end_child()
@@ -329,8 +324,6 @@ class TrainingModule:
                 directory_path = self.save_path_browser.select_directory("Select Training Results Save Path", initial_dir=self.save_path)
                 if directory_path:
                     self.save_path = directory_path
-                else:
-                    print("No save path selected")
 
             imgui.text("Dataset Path")
             current_y = imgui.get_cursor_pos_y()
@@ -356,13 +349,7 @@ class TrainingModule:
                                     self.browse_cache.append(pkl_path_str)
                     
                     if pkl_files:
-                        print(f"Found {len(pkl_files)} PKL files in directory:")
-                        for pkl in pkl_files:
-                            print(f"  - {pkl}")
-                    else:
-                        print("No PKL files found in directory")
-                else:
-                    print("No data path selected")
+                        logger.debug("Found %d PKL files in directory", len(pkl_files))
                 
             imgui.text("Resume Pkl")
             current_y = imgui.get_cursor_pos_y()
@@ -439,7 +426,6 @@ class TrainingModule:
 
             if imgui.button("Train", width=-1):
                 self._open_training_popup = True
-                print("training")
                 
                 target_data_path = self.data_path
 
@@ -456,7 +442,7 @@ class TrainingModule:
                         if img is not None:
                             height, width = img.shape[:2]
                             detected_resolution = (width, height)
-                            print(f"Detected image resolution from dataset: {detected_resolution}")
+                            logger.debug("Detected image resolution from dataset: %s", detected_resolution)
 
                 kwargs = dnnlib.EasyDict(
                     outdir=self.save_path,
@@ -512,7 +498,7 @@ class TrainingModule:
                 if self.training_process.pid is not None:
                     self.queue = mp.Queue()
                     self.reply = mp.Queue()
-                    self.training_process = mp.Process(target=train_main, args=(self.queue, self.reply), name='TrainingProcess')
+                    self.training_process = LoggedProcess(target=train_main, args=(self.queue, self.reply), name='training')
                 self.done = False
                 self.queue.put(kwargs)
                 self.training_process.start()
@@ -608,7 +594,7 @@ class TrainingModule:
                         self.dataset_done = True
                         self.is_creating_dataset = False
                         self.dataset_processed_count = completion_data.get('processed_count', 0)
-                        print(f"Dataset created! Processed {self.dataset_processed_count} images")
+                        logger.info("Dataset created: processed %d images", self.dataset_processed_count)
                         if hasattr(self, 'dataset_output_path'):
                             self.data_path = self.dataset_output_path
                         if hasattr(self, 'dataset_process') and self.dataset_process and self.dataset_process.is_alive():
@@ -661,7 +647,7 @@ class TrainingModule:
                 
                 if imgui_utils.button("Cancel", width=progress_width):
                     self.dataset_queue.put('cancel')
-                    print("Dataset creation cancelled by user")
+                    logger.info("Dataset creation cancelled by user")
                     self.cleanup_dataset_process()
                     self.folder_exists_warning = False
                     self.video_extraction_in_progress = False
@@ -786,7 +772,7 @@ class TrainingModule:
         """Start the preprocessing dataset creation process"""
         # Validate paths
         if not Path(self.preprocessing_data_path).exists():
-            print(f"Error: Data path does not exist: {self.preprocessing_data_path}")
+            logger.error("Data path does not exist: %s", self.preprocessing_data_path)
             self.dataset_message = f"Data path does not exist:\n{self.preprocessing_data_path}"
             return
         
@@ -794,7 +780,7 @@ class TrainingModule:
         image_files = self.collect_image_files(self.preprocessing_data_path)
         
         if not image_files and not self.video_files_list:
-            print("Error: No images or videos found in directory")
+            logger.error("No images or videos found in directory %s", self.preprocessing_data_path)
             self.dataset_message = "No images or videos found in the selected directory"
             return
         
@@ -833,16 +819,17 @@ class TrainingModule:
                 break
         
         if self.video_files_list:
-            print(f"Extracting frames from {len(self.video_files_list)} video(s)...")
+            logger.info("Extracting frames from %d video(s)", len(self.video_files_list))
             self.video_extraction_in_progress = True
             self.video_extraction_current = 0
             self.video_extraction_total = len(self.video_files_list)
             self.video_extraction_file = ""
             self.dataset_message = "Extracting video frames..."
             
-            video_process = mp.Process(
+            video_process = LoggedProcess(
                 target=DatasetPreprocessingUtils.extract_videos,
-                args=(self.video_files_list, self.fps, self.dataset_queue, self.dataset_reply)
+                args=(self.video_files_list, self.fps, self.dataset_queue, self.dataset_reply),
+                name='video-extract'
             )
             video_process.start()
             self.dataset_process = video_process
@@ -861,7 +848,7 @@ class TrainingModule:
                 frames = [str(f) for f in frame_path.iterdir() 
                          if f.is_file() and f.suffix.lower() in ('.jpg', '.jpeg', '.png')]
                 all_images.extend(frames)
-                print(f"Added {len(frames)} frames from {frame_path.name}")
+                logger.debug("Added %d frames from %s", len(frames), frame_path.name)
         
         # Prepare settings with all collected images
         settings = DatasetPreprocessingUtils()
@@ -871,7 +858,7 @@ class TrainingModule:
         settings.fps = self.fps
         settings.output_path = self.dataset_output_path
         
-        print(f"Processing {len(all_images)} images...")
+        logger.info("Processing %d images", len(all_images))
         self.dataset_message = f"Processing {len(all_images)} images..."
         
         # Clear queues before starting
@@ -887,9 +874,10 @@ class TrainingModule:
                 break
         
         self.dataset_queue.put(settings)
-        self.dataset_process = mp.Process(
+        self.dataset_process = LoggedProcess(
             target=DatasetPreprocessingUtils.create_training_dataset,
-            args=(self.dataset_queue, self.dataset_reply)
+            args=(self.dataset_queue, self.dataset_reply),
+            name='dataset-build'
         )
         self.dataset_process.start()
         self.video_extraction_in_progress = False
@@ -907,16 +895,16 @@ class TrainingModule:
         """Clean up dataset creation process"""
         if self.dataset_process and self.dataset_process.is_alive():
             try:
-                print("Terminating dataset creation process...")
+                logger.info("Terminating dataset creation process")
                 self.dataset_process.terminate()
                 self.dataset_process.join(timeout=2)
                 
                 if self.dataset_process.is_alive():
-                    print("Force killing dataset creation process...")
+                    logger.warning("Force killing dataset creation process")
                     self.dataset_process.kill()
                     self.dataset_process.join()
             except Exception as e:
-                print(f"Error cleaning up dataset process: {e}")
+                logger.warning("Error cleaning up dataset process: %s", e)
             finally:
                 self.dataset_process = None
         

--- a/modules/visualizer.py
+++ b/modules/visualizer.py
@@ -5,6 +5,7 @@
 # and any modifications thereto.  Any use, reproduction, disclosure or
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
+import logging
 import threading
 import numpy as np
 import queue
@@ -50,6 +51,8 @@ import ctypes
 import pandas as pd
 import os
 
+logger = logging.getLogger(__name__)
+
 #----------------------------------------------------------------------------
 class Visualizer:
     def __init__(self, app, renderer):
@@ -62,13 +65,11 @@ class Visualizer:
         self.pa = None
         # check if microphone is available
         try:
-            print("checking for microphone")
             self.pa = pyaudio.PyAudio()
-            print(self.pa)
-            print(self.pa.get_default_input_device_info())
+            logger.debug("Default input device: %s", self.pa.get_default_input_device_info())
             self.has_microphone = True
         except Exception as exc:
-            print(f"except no microphone found: {exc}")
+            logger.warning("No microphone found: %s", exc)
         self.in_ip = "127.0.0.1"
         self.in_port = 1338
         self.out_ip = "127.0.0.1"
@@ -156,7 +157,7 @@ class Visualizer:
             return
 
         try:
-            print("Setting up audio widget")
+            logger.info("Setting up audio widget")
             self.audio_widget = audio_widget.AudioWidget(self)
             self.audio_widget_enabled = True
         except NoMicrophoneError:
@@ -174,7 +175,7 @@ class Visualizer:
             try:
                 self.audio_widget.close()
             except Exception as exc:
-                print(f"Error closing audio widget: {exc}")
+                logger.warning("Error closing audio widget: %s", exc)
 
         self.audio_widget = None
         self.audio_widget_enabled = False
@@ -233,9 +234,8 @@ class Visualizer:
             
             return program
             
-        except Exception as e:
-            import traceback
-            traceback.print_exc()
+        except Exception:
+            logger.exception("Failed to compile shader program")
             return None
 
     def create_fullscreen_window(self):
@@ -378,7 +378,7 @@ class Visualizer:
             return None
             
         except Exception as e:
-            print(f"Error creating window: {e}")
+            logger.error("Error creating fullscreen window: %s", e)
             if 'window' in locals() and window:
                 glfw.destroy_window(window)
             return None
@@ -449,7 +449,7 @@ class Visualizer:
             glfw.make_context_current(self.main_window_context)
             
         except Exception as e:
-            print(f"渲染时出错: {e}")
+            logger.error("Fullscreen render failed: %s", e)
 
     def start_recording(self, file_path):
         self.is_recording = True
@@ -489,10 +489,10 @@ class Visualizer:
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             cv2.imwrite(file_path, image_data)
         else:
-            print("No render result available to capture.")
+            logger.warning("No render result available to capture")
 
     def osc_message_handler(self, address, *args):
-        print(f"[DEBUG] OSC message received at {address} with arguments: {args}")
+        logger.debug("OSC message received at %s with arguments: %s", address, args)
 
 
 
@@ -521,7 +521,7 @@ class Visualizer:
     def print_error(self, error):
         error = str(error)
         if error != self._last_error_print:
-            print('\n' + error + '\n')
+            logger.error("%s", error)
             self._last_error_print = error
 
     def defer_rendering(self, num_frames=1):
@@ -753,7 +753,7 @@ class Visualizer:
                         self.frame_queue.put(frame_to_record)
                         self.frames_captured += 1
                         if self.frames_captured % 30 == 0:  
-                            print(f"Captured {self.frames_captured} frames")
+                            logger.debug("Captured %d frames", self.frames_captured)
                     except Exception:
                         pass
                 

--- a/modules/welcome.py
+++ b/modules/welcome.py
@@ -17,7 +17,6 @@ class Welcome:
     def __init__(self, app):
         self.app = app
         self.splash = cv2.imread("assets/splashscreen.jpg")
-        print(self.splash.shape)
         self.splash = cv2.cvtColor(self.splash, cv2.COLOR_BGR2RGB)
         self.splash_texture = gl_utils.Texture(image=self.splash, width=self.splash.shape[1], height=self.splash.shape[0], channels=self.splash.shape[2])
 

--- a/projection/bayle_projection.py
+++ b/projection/bayle_projection.py
@@ -12,12 +12,15 @@
 """Project given image to the latent space of pretrained network pickle."""
 
 import copy
+import logging
 import os
 from time import perf_counter
 
 import multiprocessing as mp
 import clip
 import imageio
+
+logger = logging.getLogger(__name__)
 import numpy as np
 import PIL.Image
 from PIL import ImageFilter
@@ -109,7 +112,7 @@ def project(
     verbose                    = False,
     device: torch.device
 ):
-    print("target text", target_text, target_text == None, target_text == "")
+    logger.debug("Projection target text: %r", target_text)
     curr_img = None
     if target_image is not None:
         assert target_image.shape == (G.img_channels, G.img_resolution, G.img_resolution)
@@ -433,7 +436,7 @@ def run_projection(
 
     # Render debug output: optional video and projected image and W vector.
     if save_video:
-        print('Generating optimization progress video...')
+        logger.info('Generating optimization progress video...')
 
         video = imageio.get_writer(f'{save_path}/proj.mp4', mode='I', fps=10, codec='libx264', bitrate='16M')
         reply_queue.put([f'Saving optimization progress video "{save_path}/proj.mp4"', None, True, False])

--- a/prune.py
+++ b/prune.py
@@ -1,3 +1,4 @@
+import logging
 import copy
 import os
 import pickle
@@ -16,6 +17,8 @@ from training.distillation.Util.mask_util import Mask_the_Generator
 from training.distillation.Util.network_util import Get_Network_Shape
 from training.distillation.Util.pruning_util import Get_Uniform_RmveList, Generate_Prune_Mask_List
 
+logger = logging.getLogger(__name__)
+
 
 @click.command()
 @click.argument('pkl', metavar='PATH', nargs=-1)
@@ -31,7 +34,6 @@ def clickmain(pkl, outdir, n_samples, batch_size, noise_prob, remove_ratio, cust
 
 def main(pkl, outdir, n_samples, batch_size, noise_prob, remove_ratio, custom=True, info_print=False):
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    print("CUSTOM", custom)
     # Generator Loading
 
     with dnnlib.util.open_url(pkl, verbose=False) as f:
@@ -51,7 +53,7 @@ def main(pkl, outdir, n_samples, batch_size, noise_prob, remove_ratio, custom=Tr
 
     end_time = time.time()
 
-    print('The content-aware metric scoring takes: ' + str(round(end_time - start_time, 4)) + ' seconds')
+    logger.info('Content-aware metric scoring took %s seconds', round(end_time - start_time, 4))
 
     # Generator Pruning
     net_shape = Get_Network_Shape(g_ema)

--- a/super_res/super_res.py
+++ b/super_res/super_res.py
@@ -1,3 +1,4 @@
+import logging
 import torch
 from torch import nn
 from tqdm import tqdm
@@ -18,6 +19,8 @@ from utils.downloads import download_file
 import threading
 import time
 import gc
+
+logger = logging.getLogger(__name__)
 
 # Downloadable Real-ESRGAN weights: display name -> (original filename, url).
 # "Fast" is omitted -- it is a small custom model bundled with the app.
@@ -51,13 +54,12 @@ def ensure_sr_weight(model_type, progress_cb=None, cancel_event=None):
     if model_type in SR_WEIGHTS and not os.path.exists(path):
         _, url = SR_WEIGHTS[model_type]
         if progress_cb is None:
+            logger.info("Downloading %s super-resolution weights from %s", model_type, url)
             def progress_cb(done, total):
-                pct = f"{done / total:6.1%}" if total else f"{done} bytes"
-                print(f"\rDownloading {model_type} weights: {pct}", end="", flush=True)
+                pass
         if cancel_event is None:
             cancel_event = threading.Event()
         ok = download_file(url, path, cancel_event, progress_cb)
-        print()
         if not ok:
             return None
     return path
@@ -119,7 +121,7 @@ class Reader:
 class Writer:
 
     def __init__(self, args, audio, height, width, video_save_path, fps):
-        print("SAVING VIDEO TO: ", video_save_path)
+        logger.info("Saving video to %s", video_save_path)
         if args.scale_mode:
           out_width, out_height = int(width * args.outscale), int(height * args.outscale)
         else:
@@ -174,7 +176,7 @@ def base_args():
 
 
 def process(args,file):
-  print("Processing", args)
+  logger.debug("Processing %s with args %s", file, args)
   model_path = ensure_sr_weight(args.model_type)
 
   upsampler=load_model(args.model_type,model_path)
@@ -183,7 +185,7 @@ def process(args,file):
     width, height = get_resolution(file)
 
     if args.outscale > 4 or (check_width_height(args) and (args.out_width > 4*width or args.out_height > 4*height)):
-      print('warning: Any super-res scale larger than x4 required non-model inference with interpolation and can be slower')
+      logger.warning('Super-res scale larger than x4 requires non-model inference with interpolation and can be slower')
 
 
     audio = get_audio(file)
@@ -196,8 +198,8 @@ def process(args,file):
 
     cap = cv2.VideoCapture(file)
     frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-    print("Framecount",frame_count)
-    pbar = tqdm(total=frame_count, unit='frame', desc='inference')
+    logger.debug("Frame count: %d", frame_count)
+    pbar = tqdm(total=frame_count, unit='frame', desc='inference', disable=None)
 
     fps = cap.get(cv2.CAP_PROP_FPS)
 
@@ -237,7 +239,6 @@ def process(args,file):
         ret, img = cap.read()
 
       else:
-        print('break')
         break
 
     writer.close()
@@ -246,13 +247,11 @@ def process(args,file):
     data_transformer = transforms.Compose([transforms.ToTensor()])
     image = cv2.imread(file)
     input_width, input_height = image.shape[0], image.shape[1]
-    print("INPUT DIMENSIONS", input_width, input_height, image.shape)
     image = data_transformer(image).to(get_device())
     input = torch.unsqueeze(image, 0)
 
     with torch.inference_mode():
           output = upsampler(input)
-          print("OUTPUT DIMENSIONS", output.shape)
           output = F.adjust_sharpness(output, args.sharpen_scale) * 255
 
           output = output[0].permute(1, 2, 0).cpu().numpy().astype(np.uint8)
@@ -273,7 +272,6 @@ def process(args,file):
                   ), interpolation=cv2.INTER_LINEAR)
 
     if args.scale_mode:
-      print("USING these params", input_width, input_height, args.outscale)
       path = os.path.join(args.result_path,
                             tail[
                             :-4] + f'_result_{args.model_type}_{int(input_width * args.outscale)}x{int(input_height * args.outscale)}_Sharpness{args.sharpen_scale}.jpg')
@@ -283,7 +281,7 @@ def process(args,file):
                           tail[
                           :-4] + f'_result_{args.model_type}_{int(args.out_width)}x{int(args.out_height)}_Sharpness{args.sharpen_scale}.jpg')
 
-    print("Saving image to {}".format(path))
+    logger.info("Saving image to %s", path)
     cv2.imwrite(path, output)
 
 
@@ -291,7 +289,7 @@ def process(args,file):
 
 def _sr_image(model, args, file, tail, file_idx, reply_queue):
     reply_queue.put([file_idx, 0, 1, -1, False])
-    print(f"Super-res image: {file}")
+    logger.info("Super-res image: %s", file)
     data_transformer = transforms.Compose([transforms.ToTensor()])
     image = cv2.imread(file)
     input_height, input_width = image.shape[0], image.shape[1]
@@ -308,7 +306,7 @@ def _sr_image(model, args, file, tail, file_idx, reply_queue):
             output = cv2.resize(output, (int(args.out_width), int(args.out_height)), interpolation=cv2.INTER_LINEAR)
         path = os.path.join(args.result_path, tail[:-4] + f'_result_{args.model_type}_{int(input_width * args.outscale)}x{int(input_height * args.outscale)}_Sharpness{args.sharpen_scale}.jpg')
         cv2.imwrite(path, output)
-    print(f"Saved {path}")
+    logger.info("Saved %s", path)
     reply_queue.put([file_idx, 1, 1, -1, False])
 
 
@@ -324,7 +322,7 @@ def _sr_video(model, args, file, tail, file_idx, reply_queue):
         video_save_path = os.path.join(args.result_path, tail[:-4] + f'_result_{args.model_type}_{int(video_width * args.outscale)}x{int(video_height * args.outscale)}_Sharpness{args.sharpen_scale}.mp4')
     else:
         video_save_path = os.path.join(args.result_path, tail[:-4] + f'_result_{args.model_type}_{int(args.out_width)}x{int(args.out_height)}_Sharpness{args.sharpen_scale}.mp4')
-    print(f"Saving video to {video_save_path}")
+    logger.info("Saving video to %s", video_save_path)
     writer = Writer(args, audio, video_height, video_width, video_save_path=video_save_path, fps=fps)
     reader = Reader(video_width, video_height, file)
     start_time = time.time()
@@ -346,7 +344,6 @@ def _sr_video(model, args, file, tail, file_idx, reply_queue):
                 sr_output = cv2.resize(sr_output, (int(args.out_width), int(args.out_height)), interpolation=cv2.INTER_LINEAR)
             writer.write_frame(sr_output)
         super_res_idx += 1
-        print(f"Processing frame {super_res_idx}/{total_frames}")
         now = time.time()
         if now - last_put >= 0.15 or super_res_idx >= total_frames:
             eta = (now - start_time) / super_res_idx * max(total_frames - super_res_idx, 0)
@@ -380,15 +377,14 @@ def main(args):
   if not os.path.exists(args.result_path):
     os.makedirs(args.result_path)
 
-  print(list_file)
+  logger.debug("Files to process: %s", list_file)
   for file in list_file:
-    print(f'working on {file}')
+    logger.info('Super resolution: working on %s', file)
     if file[-3:] == 'jpg' or file[-3:] == 'png':
       process(args,file)
     if file[-3:] == 'mp4' or file[-3:] == 'avi' or args.input_path[-3:] == 'mov':
-      print(f'working on {file}')
       process(args,file)
-  print('Done')
+  logger.info('Super resolution done')
 
 if __name__ == '__main__':
     parser = base_args()

--- a/super_resolution.py
+++ b/super_resolution.py
@@ -1,3 +1,4 @@
+import logging
 import gc
 import os
 
@@ -15,6 +16,9 @@ from utils import device_utils
 from utils.device_utils import get_device
 from super_res.super_res import ensure_sr_weight
 
+
+
+logger = logging.getLogger(__name__)
 
 def get_audio(video_path):
     probe = ffmpeg.probe(video_path)
@@ -138,11 +142,11 @@ def super_res_main(input_dir, output_dir, scale_mode, sharpening_factor, model, 
 
     msg += " and sharpening factor " + str(sharpening_factor)
 
-    print(msg)
+    logger.info("%s", msg)
 
     model_path = ensure_sr_weight(model)
 
-    print("Loading Model", model_path)
+    logger.info("Loading model %s", model_path)
     super_res_model = load_model(model, model_path)
 
     # if output directory does not exist create it
@@ -158,8 +162,7 @@ def super_res_main(input_dir, output_dir, scale_mode, sharpening_factor, model, 
         else:
             low_res_files.append(f)
 
-    print("Found", len(low_res_files), "files to upscale:", low_res_files)
-    print("Starting Super Resolution")
+    logger.info("Found %d files to upscale", len(low_res_files))
     for file in tqdm(low_res_files, desc="Super Res", unit="files", position=0, leave=True,):
         # if file is an image perform super res on it
         if file.endswith(('.jpg', '.jpeg', '.png')):
@@ -252,7 +255,7 @@ def super_res_main(input_dir, output_dir, scale_mode, sharpening_factor, model, 
             device_utils.empty_cache()
             gc.collect()
         else:
-            print("File type not supported. \n Supported file types are: \n jpg, jpeg, png, mp4, avi, mov")
+            logger.warning("File type not supported: %s (supported: jpg, jpeg, png, mp4, avi, mov)", file)
 
 
 if __name__ == "__main__":

--- a/train.py
+++ b/train.py
@@ -9,6 +9,7 @@
 """Train a GAN using the techniques described in the paper
 "Alias-Free Generative Adversarial Networks"."""
 
+import logging
 import os
 import click
 import re
@@ -22,7 +23,6 @@ if sys.platform == 'darwin':
     os.environ.setdefault('PYTORCH_ENABLE_MPS_FALLBACK', '1')
 
 import torch
-import traceback
 
 import dnnlib as dnnlib
 from training import training_loop
@@ -30,11 +30,13 @@ from metrics import metric_main
 from torch_utils import training_stats, custom_ops
 from queue import Empty
 
+logger = logging.getLogger(__name__)
+
 
 #----------------------------------------------------------------------------
 
 def subprocess_fn(rank, c, temp_dir, queue, reply):
-    print(f"Rank: {rank}, Configuration (c): {c}")
+    logger.debug("Training subprocess rank=%d config=%s", rank, c)
     dnnlib.util.Logger(file_name=os.path.join(c.run_dir, 'log.txt'), file_mode='a', should_flush=True)
 
     try:
@@ -53,23 +55,18 @@ def subprocess_fn(rank, c, temp_dir, queue, reply):
         # Init torch_utils.
         sync_device = torch.device('cuda', rank) if c.num_gpus > 1 else None
         training_stats.init_multiprocessing(rank=rank, sync_device=sync_device)
-        print(rank)
         if rank != 0:
             custom_ops.verbosity = 'none'
 
         # Execute training loop.
         training_loop.training_loop(rank=rank, **c, queue=queue, reply=reply)
-    except Exception as e:
-        print(f"Caught an exception of type: {type(e).__name__}")
-        print(f"Exception message: {str(e)}")
-        print("Traceback1:")
-        traceback.print_exc()
+    except Exception:
+        logger.exception("Training subprocess failed")
         reply.put(['Exception occured in subprocess_fn...', True])
 
 #----------------------------------------------------------------------------
 
 def launch_training(c, desc, outdir, dry_run, queue, reply):
-    dnnlib.util.Logger(should_flush=True)
     # Pick output directory.
     prev_run_dirs = []
     if os.path.isdir(outdir):
@@ -80,50 +77,38 @@ def launch_training(c, desc, outdir, dry_run, queue, reply):
     c.run_dir = os.path.join(outdir, f'{cur_run_id:05d}-{desc}')
     assert not os.path.exists(c.run_dir)
 
-    # Print options.
-    print()
-    print('Training options:')
     reply.put(['Training options:' + json.dumps(c, indent=2), False])
-    print(json.dumps(c, indent=2))
-    print()
-    print(f'Output directory:    {c.run_dir}')
-    print(f'Number of GPUs:      {c.num_gpus}')
-    print(f'Batch size:          {c.batch_size} images')
-    print(f'Training duration:   {c.total_kimg} kimg')
-    print(f'Dataset path:        {c.training_set_kwargs.path}')
-    print(f'Dataset size:        {c.training_set_kwargs.max_size} images')
-    print(f'Dataset resolution:  {c.training_set_kwargs.resolution}')
-    print(f'Dataset Height and width:  {c.training_set_kwargs.height} {c.training_set_kwargs.width}')
-    print(f'Dataset labels:      {c.training_set_kwargs.use_labels}')
-    print(f'Dataset x-flips:     {c.training_set_kwargs.xflip}')
-    print()
+    logger.debug('Training options: %s', json.dumps(c, indent=2))
+    logger.info('Starting training run: run_dir=%s gpus=%d batch=%d kimg=%d '
+                'dataset=%s resolution=%s',
+                c.run_dir, c.num_gpus, c.batch_size, c.total_kimg,
+                c.training_set_kwargs.path, c.training_set_kwargs.resolution)
 
     # Dry run?
     if dry_run:
-        print('Dry run; exiting.')
+        logger.info('Dry run; exiting.')
         return
 
     # Create output directory.
-    print('Creating output directory...')
     os.makedirs(c.run_dir)
     with open(os.path.join(c.run_dir, 'training_options.json'), 'wt') as f:
         json.dump(c, f, indent=2)
 
     # Launch processes.
-    print('Launching processes...')
     try:
         torch.multiprocessing.set_start_method('spawn', force=True)
         with tempfile.TemporaryDirectory() as temp_dir:
             subprocess_fn(rank=0, c=c, temp_dir=temp_dir, queue=queue, reply=reply)
-    except:
+    except Exception:
+        logger.exception('launch_training failed')
         reply.put(['Exception occured in launch_training...', True])
 
 #----------------------------------------------------------------------------
 
 def init_dataset_kwargs(data, resolution=None, height = None, width = None, fps=10, resize_mode='stretch', skip_preprocessing=True):
     try:
-        print("RESOLUTION: ", resolution, height, width)
-        print("SKIP_PREPROCESSING: ", skip_preprocessing)
+        logger.debug("Dataset kwargs: resolution=%s height=%s width=%s skip_preprocessing=%s",
+                     resolution, height, width, skip_preprocessing)
         dataset_kwargs = dnnlib.EasyDict(
             class_name='training.dataset.ImageFolderDataset', 
             path=data, 
@@ -247,7 +232,7 @@ def main(queue, reply):
 
         # Initialize config.
         kwargs = queue.get()
-        print("kwargs", kwargs)
+        logger.debug("Training kwargs: %s", kwargs)
 
         opts = dnnlib.EasyDict(**kwargs) # Command line arguments.
         c = dnnlib.EasyDict() # Main config dict.
@@ -323,7 +308,7 @@ def main(queue, reply):
 
 
         if list(init_res) != [4, 4]:
-            print(' custom init resolution', init_res)
+            logger.debug('Custom init resolution: %s', init_res)
             c.G_kwargs.init_res = c.D_kwargs.init_res = list(init_res)
 
         # Sanity checks.
@@ -358,7 +343,6 @@ def main(queue, reply):
                 c.loss_kwargs.blur_fade_kimg = c.batch_size * 200 / 32 # Fade out the blur during the first N kimg.
 
         if opts.topk is not None:
-            print("topking-------")
             assert isinstance(opts.topk, float)
             c.loss_kwargs.G_top_k = True
             c.loss_kwargs.G_top_k_gamma = opts.topk
@@ -435,11 +419,8 @@ def main(queue, reply):
             if queue.get(block=False) == 'done':
                 reply.put(['Training Process Aborted... Please close this window.', True])
         launch_training(c=c, desc=desc, outdir=opts.outdir, dry_run=opts.dry_run, queue=queue, reply=reply)
-    except Exception as e:
-        print(f"Caught an exception of type: {type(e).__name__}")
-        print(f"Exception message: {str(e)}")
-        print("Traceback2:")
-        traceback.print_exc()
+    except Exception:
+        logger.exception("Training process could not start")
         reply.put(['Training Process Could not Start... Please close this window.', True])
 
 #----------------------------------------------------------------------------

--- a/training/dataset.py
+++ b/training/dataset.py
@@ -20,7 +20,9 @@ import torchvision.transforms
 import json
 import torch
 import dnnlib
-import traceback
+import logging
+
+logger = logging.getLogger(__name__)
 
 try:
     import pyspng
@@ -445,9 +447,8 @@ class ImageFolderDataset(Dataset):
                     else:
                         print(f"Failed to extract frames from {video_path}, ffmpeg returned {result}")
                         
-                except Exception as e:
-                    print(f"Error processing video {video_path}: {str(e)}")
-                    traceback.print_exc()
+                except Exception:
+                    logger.exception("Error processing video %s", video_path)
                 finally:
                     if self._type == 'zip' and 'temp_dir' in locals():
                         import shutil

--- a/training/training_loop.py
+++ b/training/training_loop.py
@@ -8,6 +8,7 @@
 
 """Main training loop."""
 
+import logging
 import os
 import time
 import copy
@@ -17,7 +18,6 @@ import psutil
 import PIL.Image
 import numpy as np
 import torch
-import traceback
 import dnnlib as dnnlib
 from torch_utils import misc, training_stats, legacy as legacy
 from torch_utils.ops import conv2d_gradfix, grid_sample_gradfix
@@ -26,6 +26,8 @@ from queue import Empty
 
 from metrics import metric_main
 from codecarbon import EmissionsTracker
+
+logger = logging.getLogger(__name__)
 
 #----------------------------------------------------------------------------
 
@@ -165,11 +167,8 @@ def training_loop(
             training_set.save_resized(run_dir)
             training_set.copy_frames_folders(run_dir)
             print()
-    except Exception as e:
-        print(f"Caught an exception of type: {type(e).__name__}")
-        print(f"Exception message: {str(e)}")
-        print("Traceback3:")
-        traceback.print_exc()
+    except Exception:
+        logger.exception("Failed to load training set")
         reply.put(['Exception occured during Loading of Training Set..', True])
 
     # Construct networks.
@@ -187,10 +186,9 @@ def training_loop(
 
         G.update_epochs(float(100 * nimg / (total_kimg * 1000)))  # 100 total top k "epochs" in total_kimg
         print('starting G epochs: ', G.epochs)
-    except:
+    except Exception:
+        logger.exception("Failed to construct networks")
         reply.put(['Exception occured during Network Construction..', True])
-        traceback.print_exc()  # Prints the full traceback for better debugging
-        reply.put(['Exception occurred during Network Construction..', True])
 
     # Resume from existing pickle.
     try:
@@ -220,7 +218,6 @@ def training_loop(
         c = torch.empty([batch_gpu, G.c_dim], device=device)
         # img, _ = misc.print_module_summary(G, [z, c])
         output = misc.print_module_summary(G, [z, c])
-        print(output)
         if len(output) == 1:
             misc.print_module_summary(D, [output, c])
         else:
@@ -301,11 +298,8 @@ def training_loop(
 
             save_image_grid(images, os.path.join(run_dir, 'fakes_init.png'), drange=[-1,1], grid_size=grid_size)
             reply.put([str(os.path.join(run_dir, 'fakes_init.png')), False])
-    except Exception as e:
-        print(f"Caught an exception of type: {type(e).__name__}")
-        print(f"Exception message: {str(e)}")
-        print("Traceback4:")
-        traceback.print_exc()
+    except Exception:
+        logger.exception("Failed to export sample images")
         reply.put(['Exception occured during Exporting of Sample Images..', True])
 
     # Initialize logs.

--- a/utils/app_logging.py
+++ b/utils/app_logging.py
@@ -1,0 +1,277 @@
+"""Central logging for every Autolume process.
+
+The main process owns the only file handler: a daily-rotating
+``<data_root>/logs/autolume.log`` drained by a :class:`~logging.handlers.QueueListener`
+thread. Every process (main and spawned children alike) logs through a shared
+``multiprocessing.Queue`` via :class:`~logging.handlers.QueueHandler`, so rotation
+is safe on Windows (a single writer) and disk I/O stays off the GUI thread.
+
+Wiring:
+- Main process: call :func:`setup_main_logging` once, inside the ``__main__`` guard.
+- Child processes: spawn workers with :class:`LoggedProcess` instead of
+  ``multiprocessing.Process`` — the child configures itself before running.
+- Pool workers: pass ``initializer=pool_worker_init,
+  initargs=(get_log_queue(), "<name>")`` to ``multiprocessing.Pool``.
+
+Every process also redirects ``sys.stdout``/``sys.stderr`` into the log (safety
+net for vendored dnnlib/torch_utils prints and third-party libraries — required
+in the macOS windowed build where those streams are otherwise gone), installs
+``sys.excepthook``/``threading.excepthook``, and enables ``faulthandler`` on an
+append-only ``logs/crashes.log`` for native crashes.
+"""
+import atexit
+import faulthandler
+import logging
+import logging.handlers
+import multiprocessing
+import os
+import re
+import sys
+import tempfile
+import threading
+import traceback
+
+LOG_DIR_NAME = "logs"
+LOG_FILE_NAME = "autolume.log"
+CRASH_FILE_NAME = "crashes.log"
+BACKUP_DAYS = 14
+LOG_FORMAT = "%(asctime)s %(levelname)-7s [%(processName)s] %(name)s: %(message)s"
+NOISY_THIRD_PARTY_LOGGERS = ("PIL", "matplotlib", "urllib3", "numba")
+
+_log_queue = None
+_listener = None
+_crash_file = None
+_configured = False
+
+
+def _resolve_log_dir():
+    """Directory for log files, or None if nowhere is writable. Never raises."""
+    try:
+        from utils.user_data import ensure_data_path
+        return ensure_data_path(LOG_DIR_NAME)
+    except Exception:
+        pass
+    try:
+        from pathlib import Path
+        fallback = Path(tempfile.gettempdir()) / "autolume" / LOG_DIR_NAME
+        fallback.mkdir(parents=True, exist_ok=True)
+        return fallback
+    except Exception:
+        return None
+
+
+class _StreamToLogger:
+    """File-like object routing writes to a logger, line by line.
+
+    Deliberately has no ``fileno()``: callers that need a real file descriptor
+    (e.g. faulthandler) must not be handed this object.
+    """
+
+    def __init__(self, logger, level):
+        self._logger = logger
+        self._level = level
+        self._buffer = ""
+        self._emitting = False
+
+    def _emit(self, line):
+        if self._emitting:
+            return
+        self._emitting = True
+        try:
+            self._logger.log(self._level, line)
+        finally:
+            self._emitting = False
+
+    def write(self, text):
+        if not isinstance(text, str):
+            text = str(text)
+        self._buffer += text
+        *lines, self._buffer = re.split(r"[\r\n]", self._buffer)
+        for line in lines:
+            if line.strip():
+                self._emit(line)
+        return len(text)
+
+    def flush(self):
+        if self._buffer.strip():
+            self._emit(self._buffer)
+        self._buffer = ""
+
+    def writelines(self, lines):
+        for line in lines:
+            self.write(line)
+
+    def isatty(self):
+        return False
+
+
+def _configure_root(log_queue, level):
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(logging.handlers.QueueHandler(log_queue))
+    root.setLevel(level)
+    for name in NOISY_THIRD_PARTY_LOGGERS:
+        logging.getLogger(name).setLevel(logging.WARNING)
+
+
+def _log_level():
+    return os.environ.get("AUTOLUME_LOG_LEVEL", "INFO").upper()
+
+
+def _install_runtime_capture(log_dir):
+    """Redirect std streams, hook uncaught exceptions, enable faulthandler."""
+    global _crash_file
+
+    sys.stdout = _StreamToLogger(logging.getLogger("stdout"), logging.INFO)
+    sys.stderr = _StreamToLogger(logging.getLogger("stderr"), logging.WARNING)
+
+    def _excepthook(exc_type, exc_value, exc_tb):
+        logging.getLogger("autolume").critical(
+            "Uncaught exception", exc_info=(exc_type, exc_value, exc_tb))
+        if sys.__stderr__ is not None:
+            traceback.print_exception(exc_type, exc_value, exc_tb, file=sys.__stderr__)
+
+    def _thread_excepthook(args):
+        thread_name = args.thread.name if args.thread else "unknown"
+        logging.getLogger("autolume").critical(
+            "Uncaught exception in thread %s", thread_name,
+            exc_info=(args.exc_type, args.exc_value, args.exc_traceback))
+
+    sys.excepthook = _excepthook
+    threading.excepthook = _thread_excepthook
+    logging.captureWarnings(True)
+
+    if log_dir is not None:
+        try:
+            _crash_file = open(log_dir / CRASH_FILE_NAME, "a", encoding="utf-8")
+            _crash_file.write("--- pid %d (%s) started ---\n"
+                              % (os.getpid(), multiprocessing.current_process().name))
+            _crash_file.flush()
+            faulthandler.enable(file=_crash_file, all_threads=True)
+        except Exception:
+            _crash_file = None
+
+
+def setup_main_logging(level=None):
+    """Configure logging for the main process. Idempotent, never raises."""
+    global _log_queue, _listener, _configured
+    if _configured:
+        return
+    _configured = True
+
+    level = (level or _log_level())
+    formatter = logging.Formatter(LOG_FORMAT)
+    handlers = []
+
+    log_dir = _resolve_log_dir()
+    if log_dir is not None:
+        try:
+            file_handler = logging.handlers.TimedRotatingFileHandler(
+                str(log_dir / LOG_FILE_NAME), when="midnight",
+                backupCount=BACKUP_DAYS, encoding="utf-8", delay=True)
+            file_handler.setFormatter(formatter)
+            handlers.append(file_handler)
+        except Exception:
+            log_dir = None
+    if sys.__stderr__ is not None:
+        console_handler = logging.StreamHandler(sys.__stderr__)
+        console_handler.setFormatter(formatter)
+        handlers.append(console_handler)
+
+    _log_queue = multiprocessing.get_context("spawn").Queue(-1)
+    _listener = logging.handlers.QueueListener(
+        _log_queue, *handlers, respect_handler_level=True)
+    _listener.start()
+
+    _configure_root(_log_queue, level)
+    _install_runtime_capture(log_dir)
+    atexit.register(shutdown_logging)
+
+    logger = logging.getLogger("autolume")
+    try:
+        from utils.resource_paths import get_version
+        version = get_version()
+    except Exception:
+        version = "unknown"
+    try:
+        from utils.user_data import data_root
+        root = data_root()
+    except Exception:
+        root = "unknown"
+    frozen = bool(getattr(sys, "frozen", False))
+    logger.info("Autolume %s starting: platform=%s python=%s frozen=%s "
+                "data_root=%s log_dir=%s",
+                version, sys.platform, sys.version.split()[0], frozen, root, log_dir)
+
+
+def shutdown_logging():
+    """Stop the listener (draining pending records) and restore std streams."""
+    global _listener, _crash_file
+    if _listener is not None:
+        try:
+            _listener.stop()
+        except Exception:
+            pass
+        _listener = None
+    if isinstance(sys.stdout, _StreamToLogger) and sys.__stdout__ is not None:
+        sys.stdout = sys.__stdout__
+    if isinstance(sys.stderr, _StreamToLogger) and sys.__stderr__ is not None:
+        sys.stderr = sys.__stderr__
+    if _crash_file is not None:
+        try:
+            faulthandler.disable()
+            _crash_file.close()
+        except Exception:
+            pass
+        _crash_file = None
+    logging.shutdown()
+
+
+def get_log_queue():
+    """The shared log queue (None if logging was never configured)."""
+    return _log_queue
+
+
+def configure_child_logging(log_queue, name=None):
+    """Attach this (child) process to the parent's log queue. Idempotent."""
+    global _log_queue, _configured
+    if _configured or log_queue is None:
+        return
+    _configured = True
+    _log_queue = log_queue
+    if name:
+        multiprocessing.current_process().name = name
+
+    _configure_root(log_queue, _log_level())
+
+    log_dir = None
+    try:
+        from utils.user_data import data_path
+        candidate = data_path(LOG_DIR_NAME)
+        if candidate.is_dir():
+            log_dir = candidate
+    except Exception:
+        pass
+    _install_runtime_capture(log_dir)
+
+
+def pool_worker_init(log_queue, name_prefix):
+    """``multiprocessing.Pool`` initializer wiring workers to the log queue."""
+    configure_child_logging(log_queue, "%s-%d" % (name_prefix, os.getpid()))
+
+
+class LoggedProcess(multiprocessing.Process):
+    """Drop-in ``multiprocessing.Process`` that wires logging in the child."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._log_queue = get_log_queue()
+
+    def run(self):
+        configure_child_logging(self._log_queue)
+        try:
+            super().run()
+        except Exception:
+            logging.getLogger("autolume").exception(
+                "Unhandled exception in process %s", self.name)
+            raise SystemExit(1)

--- a/utils/dataset_preprocessing_utils.py
+++ b/utils/dataset_preprocessing_utils.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 
@@ -9,6 +10,8 @@ import torchvision.transforms as transforms
 import ffmpeg
 
 from utils.user_data import data_path
+
+logger = logging.getLogger(__name__)
 
 
 class DatasetPreprocessingUtils:
@@ -160,7 +163,7 @@ class DatasetPreprocessingUtils:
                     pass
         
         if duration is None:
-            print(f"Warning: Could not determine duration for video {video_path}, using default estimate")
+            logger.warning("Could not determine duration for video %s, using default estimate", video_path)
             duration = 0
         
         expected_frames = int(duration * fps) if duration > 0 else 0
@@ -203,7 +206,7 @@ class DatasetPreprocessingUtils:
                 ffmpeg.input(video_path).output(output_pattern, vf=f"fps={fps}").run()
                 results.append(str(save_path))
             except ffmpeg.Error as e:
-                print(f"FFmpeg failed for {video_path}: {e}")
+                logger.error("FFmpeg failed for %s: %s", video_path, e)
                 continue
 
         queue_out.put({'type': 'completed', 'results': results})
@@ -317,19 +320,10 @@ class DatasetPreprocessingUtils:
         
         os.makedirs(output_path, exist_ok=True)
         
-        # Debug print settings
-        print("=== DATASET PREPROCESSING SETTINGS ===")
-        print(f"Images: {len(images)} files")
-        print(f"Resolution: {size}x{size}")
-        print(f"Resize Mode: {resizeMode}")
-        print(f"Non-square: {nonSquare}")
-        if nonSquare:
-            print(f"  Width Ratio: {nonSquareSettings['widthRatio']}")
-            print(f"  Height Ratio: {nonSquareSettings['heightRatio']}")
-            print(f"  Padding Mode: {nonSquareSettings['paddingMode']}")
-        print(f"X-Flip Augmentation: {augmentationSettings['xFlip']}")
-        print(f"Y-Flip Augmentation: {augmentationSettings['yFlip']}")
-        print("=====================================")
+        logger.info("Dataset preprocessing: %d images, resolution=%dx%d, resize_mode=%s, "
+                    "non_square=%s, xflip=%s, yflip=%s",
+                    len(images), size, size, resizeMode, nonSquare,
+                    augmentationSettings['xFlip'], augmentationSettings['yFlip'])
         
         processed_count = 0
         total_source_images = len(images)
@@ -346,7 +340,7 @@ class DatasetPreprocessingUtils:
                 if not queue.empty():
                     try:
                         if queue.get_nowait() == 'cancel':
-                            print("Batch preprocessing cancelled by user")
+                            logger.info("Batch preprocessing cancelled by user")
                             reply.put(['Batch preprocessing cancelled', True])
                             return None
                     except:
@@ -362,7 +356,7 @@ class DatasetPreprocessingUtils:
                     if not queue.empty():
                         try:
                             if queue.get_nowait() == 'cancel':
-                                print("Batch preprocessing cancelled by user")
+                                logger.info("Batch preprocessing cancelled by user")
                                 reply.put(['Batch preprocessing cancelled', True])
                                 return None
                         except:
@@ -384,11 +378,11 @@ class DatasetPreprocessingUtils:
                             'current_file': Path(image_path).name
                         })
                     
-            except Exception as e:
-                print(f"Error processing image {i}: {str(e)}")
+            except Exception:
+                logger.exception("Error processing image %d", i)
                 continue
         
-        print(f"Dataset processing completed. {processed_count} images processed and saved to {output_path}")
+        logger.info("Dataset processing completed: %d images saved to %s", processed_count, output_path)
 
         completion_data = {
             'type': 'completed',

--- a/utils/dataset_tool.py
+++ b/utils/dataset_tool.py
@@ -10,6 +10,7 @@
 
 import functools
 import gzip
+import logging
 import io
 import json
 import os
@@ -26,10 +27,12 @@ import numpy as np
 import PIL.Image
 from tqdm import tqdm
 
+logger = logging.getLogger(__name__)
+
 #----------------------------------------------------------------------------
 
 def error(msg):
-    print('Error: ' + msg)
+    logger.error('%s', msg)
     sys.exit(1)
 
 #----------------------------------------------------------------------------
@@ -144,8 +147,8 @@ def open_lmdb(lmdb_dir: str, *, max_images: Optional[int]):
                     yield dict(img=img, label=None)
                     if idx >= max_idx-1:
                         break
-                except:
-                    print(sys.exc_info()[1])
+                except Exception:
+                    logger.warning("Failed to read image: %s", sys.exc_info()[1])
 
     return max_idx, iterate_images()
 

--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -5,6 +5,7 @@ worker process, CLI entry points) can fetch files without importing imgui.
 """
 import csv
 import html
+import logging
 import os
 import re
 
@@ -13,6 +14,8 @@ import requests
 from utils.resource_paths import resource_path
 
 CHUNK_SIZE = 1024 * 1024
+
+logger = logging.getLogger(__name__)
 REQUIRED_COLUMNS = ('name', 'filename', 'resolution', 'author', 'license', 'url')
 
 
@@ -26,10 +29,10 @@ def load_catalog():
                 if all(row.get(col) for col in REQUIRED_COLUMNS):
                     rows.append({col: row[col].strip() for col in REQUIRED_COLUMNS})
                 else:
-                    print(f'Skipping malformed models.csv row: {row}')
+                    logger.warning('Skipping malformed models.csv row: %s', row)
             return rows
     except OSError as e:
-        print(f'Could not load models.csv: {e}')
+        logger.error('Could not load models.csv: %s', e)
         return []
 
 

--- a/utils/gui_utils/glfw_window.py
+++ b/utils/gui_utils/glfw_window.py
@@ -6,6 +6,7 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
+import logging
 import os
 import sys
 import time
@@ -14,6 +15,9 @@ import OpenGL.GL as gl
 import PIL.Image
 from . import gl_utils
 from utils.resource_paths import resource_path
+
+
+logger = logging.getLogger(__name__)
 
 def _wayland_session():
     return sys.platform == 'linux' and bool(os.environ.get('WAYLAND_DISPLAY'))
@@ -66,7 +70,7 @@ class GlfwWindow: # pylint: disable=too-many-public-methods
             image = PIL.Image.open(resource_path('assets', 'metacreation-logo.png')).convert('RGBA')
             glfw.set_window_icon(self._glfw_window, 1, [image])
         except Exception as err: # pylint: disable=broad-except
-            print(f'Warning: failed to set window icon: {err}', file=sys.stderr)
+            logger.warning('Failed to set window icon: %s', err)
 
     def close(self):
         if self._drawing_frame:

--- a/utils/gui_utils/helper_window.py
+++ b/utils/gui_utils/helper_window.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import imgui
 import cv2
@@ -6,6 +7,9 @@ import pandas as pd
 from PIL import Image
 import imageio
 from . import gl_utils
+
+
+logger = logging.getLogger(__name__)
 
 class HelperWindow:
     """Helper window component that supports displaying text descriptions, images, GIFs and videos"""
@@ -43,7 +47,7 @@ class HelperWindow:
                 self._load_media(key)
                 
         except Exception as e:
-            print(f"Error loading help contents: {str(e)}")
+            logger.warning("Error loading help contents: %s", e)
 
     def _load_media(self, key):
         """Load media files"""
@@ -65,7 +69,7 @@ class HelperWindow:
                         channels=img.shape[2]
                     )
             except Exception as e:
-                print(f"Failed to load image {content['image_path']}: {str(e)}")
+                logger.warning("Failed to load image %s: %s", content['image_path'], e)
 
         # Load GIF
         if content['gif_path'] and os.path.exists(content['gif_path']):
@@ -90,7 +94,7 @@ class HelperWindow:
                     channels=first_frame.shape[2]
                 )
             except Exception as e:
-                print(f"Failed to load GIF {content['gif_path']}: {str(e)}")
+                logger.warning("Failed to load GIF %s: %s", content['gif_path'], e)
 
         # Load video first frame
         if content['video_path'] and os.path.exists(content['video_path']):
@@ -107,7 +111,7 @@ class HelperWindow:
                     )
                 cap.release()
             except Exception as e:
-                print(f"Failed to load video {content['video_path']}: {str(e)}")
+                logger.warning("Failed to load video %s: %s", content['video_path'], e)
 
     def update_gif_frame(self, key):
         """Update GIF frame"""
@@ -132,7 +136,7 @@ class HelperWindow:
                     self.last_update_time[key] = current_time
                     
             except Exception as e:
-                print(f"Error updating GIF frame: {str(e)}")
+                logger.warning("Error updating GIF frame: %s", e)
 
     def show_help_marker(self, key, width=200, height=200):
         """Display help marker and popup window

--- a/utils/non_square_tool.py
+++ b/utils/non_square_tool.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shutil
 import cv2
@@ -8,6 +9,14 @@ from pathlib import Path
 import multiprocessing as mp
 from functools import partial
 from tqdm import tqdm
+
+from utils.app_logging import get_log_queue, pool_worker_init
+
+logger = logging.getLogger(__name__)
+
+def _pool(num_workers):
+    return mp.Pool(num_workers, initializer=pool_worker_init,
+                   initargs=(get_log_queue(), "nonsquare"))
 
 def process_non_square_dataset(
     input_path,          # Path to input dataset
@@ -24,19 +33,11 @@ def process_non_square_dataset(
     if num_workers is None:
         num_workers = mp.cpu_count()
     
-    print(f'\n=== Starting non-square dataset processing ===')
-    print(f'Input path: {input_path}')
-    print(f'Output path: {output_path}')
-    print(f'Target ratio: {crop_ratio[0]}:{crop_ratio[1]}')
-    print(f'Padding color value: {padding_color} (type: {type(padding_color)})')
-    print(f'Resize mode: {resize_mode}')
-    print(f'Number of workers: {num_workers}')
+    logger.info('Starting non-square dataset processing: input=%s output=%s '
+                'ratio=%s:%s padding=%s resize_mode=%s workers=%d',
+                input_path, output_path, crop_ratio[0], crop_ratio[1],
+                padding_color, resize_mode, num_workers)
 
-    if padding_color == 2:
-        print(f'Padding mode: bleeding')
-    else:
-        print(f'Padding color: {"white" if padding_color == 1 else "black"}')
-    
     # Create output directory
     output_path.mkdir(parents=True, exist_ok=True)
     
@@ -56,14 +57,11 @@ def process_non_square_dataset(
     if len(files_to_process) == 0:
         raise IOError('No supported files found in the input path')
     
-    print(f'Found {len(files_to_process)} files to process')
-    
+    logger.info('Found %d files to process', len(files_to_process))
+
     # Process each file type
     target_ratio = float(crop_ratio[0]) / float(crop_ratio[1])
-    if padding_color != 2:
-        padding_value = 255 if padding_color == 1 else 0
-        print(f'Using padding value: {padding_value}')
-    
+
     frame_count = 0
     
     # Group files by type for batch processing
@@ -73,7 +71,7 @@ def process_non_square_dataset(
     
     # Process images in batches
     if image_files:
-        print(f'\nProcessing {len(image_files)} images in parallel...')
+        logger.info('Processing %d images in parallel', len(image_files))
         batch_size = max(1, len(image_files) // (num_workers * 4))
         image_batches = []
         total_processed = 0
@@ -93,10 +91,11 @@ def process_non_square_dataset(
             total=len(image_files),
             desc="Processing images",
             unit="images",
-            dynamic_ncols=True
+            dynamic_ncols=True,
+            disable=None
         )
-        
-        with mp.Pool(num_workers) as pool:
+
+        with _pool(num_workers) as pool:
             for count in pool.imap(process_images_batch, image_batches):
                 total_processed += count
                 progress_bar.update(count)
@@ -106,28 +105,28 @@ def process_non_square_dataset(
     
     # Process GIFs
     for gif_idx, fname in enumerate(gif_files):
-        print(f'\nProcessing GIF {gif_idx+1}/{len(gif_files)}: {fname}')
+        logger.info('Processing GIF %d/%d: %s', gif_idx + 1, len(gif_files), fname)
         try:
             frame_count += process_gif_parallel(
-                fname, output_path, target_ratio, padding_color, resize_mode, 
+                fname, output_path, target_ratio, padding_color, resize_mode,
                 num_workers, frame_count
             )
-        except Exception as e:
-            print(f'Error processing GIF {fname}: {e}')
+        except Exception:
+            logger.exception('Error processing GIF %s', fname)
             continue
-    
+
     # Process videos
     for video_idx, fname in enumerate(video_files):
-        print(f'\nProcessing video {video_idx+1}/{len(video_files)}: {fname}')
+        logger.info('Processing video %d/%d: %s', video_idx + 1, len(video_files), fname)
         try:
             frame_count += process_video_parallel(
                 fname, output_path, target_ratio, padding_color, resize_mode, num_workers
             )
-        except Exception as e:
-            print(f'Error processing video {fname}: {e}')
+        except Exception:
+            logger.exception('Error processing video %s', fname)
             continue
-    
-    print(f'\nDataset preprocessing completed. Total frames processed: {frame_count}')
+
+    logger.info('Dataset preprocessing completed. Total frames processed: %d', frame_count)
     return output_path
 
 def process_frame_crop(frame, target_ratio, padding_color):
@@ -238,8 +237,8 @@ def process_images_batch(args):
             processed_frame = process_frame(image, target_ratio, padding_color, resize_mode)
             save_frame(processed_frame, output_path, start_idx + i)
             count += 1
-        except Exception as e:
-            print(f'Error processing image {image_path}: {e}')
+        except Exception:
+            logger.exception('Error processing image %s', image_path)
     return count
 
 def process_video_parallel(video_path, output_path, target_ratio, padding_color, resize_mode, num_workers):
@@ -253,7 +252,7 @@ def process_video_parallel(video_path, output_path, target_ratio, padding_color,
     duration = float(video_info['duration'])
     total_frames = int(duration * fps)
     
-    print(f'Video info: {total_frames} frames @ {fps} fps')
+    logger.debug('Video info: %d frames @ %s fps', total_frames, fps)
     
     # Create temporary directory for frames
     temp_dir = os.path.join(output_path, 'temp_frames')
@@ -295,10 +294,11 @@ def process_video_parallel(video_path, output_path, target_ratio, padding_color,
             total=len(frame_files),
             desc="Processing video frames",
             unit="frames",
-            dynamic_ncols=True
+            dynamic_ncols=True,
+            disable=None
         )
-        
-        with mp.Pool(num_workers) as pool:
+
+        with _pool(num_workers) as pool:
             for count in pool.imap(process_frames_batch, batches):
                 total_processed += count
                 progress_bar.update(count)
@@ -315,7 +315,7 @@ def process_gif_parallel(gif_path, output_path, target_ratio, padding_color, res
     """Process GIF frames in parallel"""
     gif = PIL.Image.open(gif_path)
     total_frames = gif.n_frames
-    print(f'GIF info: {total_frames} frames')
+    logger.debug('GIF info: %d frames', total_frames)
     
     # Prepare batches
     batch_size = max(1, total_frames // (num_workers * 4))
@@ -354,10 +354,11 @@ def process_gif_parallel(gif_path, output_path, target_ratio, padding_color, res
         total=total_frames,
         desc="Processing GIF frames",
         unit="frames",
-        dynamic_ncols=True
+        dynamic_ncols=True,
+        disable=None
     )
-    
-    with mp.Pool(num_workers) as pool:
+
+    with _pool(num_workers) as pool:
         for count in pool.imap(process_frames_batch, batches):
             total_processed += count
             progress_bar.update(count)

--- a/utils/user_data.py
+++ b/utils/user_data.py
@@ -13,10 +13,13 @@ Layout:
   subfolders of the data root.
 """
 import json
+import logging
 import os
 from pathlib import Path
 
 PREFS_VERSION = 1
+
+logger = logging.getLogger(__name__)
 
 _prefs = None
 _data_root = None
@@ -78,6 +81,7 @@ def set_data_root(path) -> None:
     prefs = load_prefs()
     prefs["data_root"] = _data_root
     save_prefs(prefs)
+    logger.info("Data root set to %s; logs move to the new location after restart", _data_root)
 
 
 def data_path(*parts: str) -> Path:

--- a/widgets/adjuster_widget.py
+++ b/widgets/adjuster_widget.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import imgui
@@ -14,6 +15,8 @@ except ModuleNotFoundError:
 import dnnlib
 from utils.gui_utils import imgui_utils
 from widgets.native_browser_widget import NativeBrowserWidget
+
+logger = logging.getLogger(__name__)
 
 class AdjusterWidget:
 
@@ -45,8 +48,8 @@ class AdjusterWidget:
             try:
                 self.viz.osc_dispatcher.unmap(f"/{old_address}",
                                                 self.vec_handler(i))
-            except:
-                print(f"{old_address} is not mapped")
+            except Exception:
+                logger.warning("OSC address %s is not mapped", old_address)
         for i, new_address in enumerate(new_addresses):
             if self.vslide_use_osc[i] and new_address and new_address != "...":
                 self.viz.osc_dispatcher.map(f"/{new_address}",
@@ -58,18 +61,15 @@ class AdjusterWidget:
     def vec_handler(self, idx):
         def func(address, *args):
             try:
-                print(self.weights[idx], args[-1])
                 if self.vslide_use_osc[idx]:
-                    print("in")
                     f = lambda x: eval(self.vslide_mappings[idx])
                     out = f(args[-1])
                     if isinstance(out, (int, float)):
                         self.weights[idx] = f(args[-1])
-                    print("assigned")
             except Exception as e:
                 if type(args[-1]) is type(self.weights[idx]):
                     self.weights[idx] = f(args[-1])
-                print(e)
+                logger.warning("OSC vector handler failed: %s", e)
                 #self.viz.print_error(e)
 
         return func
@@ -90,8 +90,8 @@ class AdjusterWidget:
             self.vslide_address = [""] * len(self.weights)
             self.vslide_mappings = ["x"] * len(self.weights)
 
-        except Exception as e:
-            print(e)
+        except Exception:
+            logger.exception("Failed to set adjuster params")
 
     def open_vec(self, idx):
         try:
@@ -99,8 +99,8 @@ class AdjusterWidget:
 
             assert vec.shape == self.dirs[idx].shape, f"The Tensor you are loading has a different shape, Loaded Shape {vec.shape} != Target Shape {self.dirs[idx].shape}"
             self.dirs[idx] = vec
-        except Exception as e:
-            print(e)
+        except Exception:
+            logger.exception("Failed to load vector")
 
     @imgui_utils.scoped_by_object_id
     def __call__(self, show=True):
@@ -140,8 +140,8 @@ class AdjusterWidget:
                         try:
                             self.viz.osc_dispatcher.unmap(f"/{self.vslide_address[i]}",
                                                             self.vec_handler(i))
-                        except:
-                            print(f"{self.vslide_address[i]} is not mapped")
+                        except Exception:
+                            logger.warning("OSC address %s is not mapped", self.vslide_address[i])
 
                         self.vslide_address[i] = new_address
                     changed, self.vslide_mappings[i] = imgui_utils.input_text(f"##vslide_mapping{i}",

--- a/widgets/audio_widget.py
+++ b/widgets/audio_widget.py
@@ -1,5 +1,6 @@
 import imgui
 import librosa
+import logging
 import numpy as np
 import torch
 from pythonosc.udp_client import SimpleUDPClient
@@ -8,6 +9,8 @@ import dnnlib
 from assets import ACTIVE_RED
 from audio import audio_stream
 from utils.gui_utils import imgui_utils
+
+logger = logging.getLogger(__name__)
 
 chromas = ["C", "C/D", "D", "D/E", "E", "E/F", "F", "F/G" "G", "G/A", "A", "A/B", "B"]
 
@@ -82,7 +85,7 @@ class AudioWidget:
                 viz.osc_client.send_message(f"/{self.osc_addresses[key]}", [f(signal).tolist()])
                 #print(f"/{self.osc_addresses[key]}", f(signal).tolist())
             except Exception as e:
-                print(f"Error sending OSC for {key}: {e}")
+                logger.warning("Error sending OSC for %s: %s", key, e)
     @staticmethod
     def osc_process(signal_queue):
         ip, port = "127.0.0.1", 1337
@@ -95,9 +98,8 @@ class AudioWidget:
                 if use_osc:
                     f = lambda x: eval(mapping)
                     osc_client.send_message(address, [f(signal).tolist()])
-                    print(address, f(signal).tolist())
             except Exception as e:
-                print(e)
+                logger.warning("OSC process send failed: %s", e)
 
     @imgui_utils.scoped_by_object_id
     def __call__(self, show=True):
@@ -118,7 +120,7 @@ class AudioWidget:
                                          graph_size=(width * 24, height * 1.5))
                     imgui.text("Percussive Signal")
                 except Exception as e:
-                    print(e, "Audio Decomp")
+                    logger.warning("Audio decomposition plot failed: %s", e)
                 imgui.end_group()
             elif not (self.fft.data is None):
                 try:
@@ -128,7 +130,7 @@ class AudioWidget:
                     imgui.plot_histogram("##AudioSignal", plot_values, graph_size=(width * 24, height * 3),
                                          scale_min=self.fft.min, scale_max=self.fft.max)
                 except Exception as e:
-                    print(e, "AUDIO")
+                    logger.warning("Audio plot failed: %s", e)
 
             imgui.same_line()
             imgui.begin_group()
@@ -153,6 +155,6 @@ class AudioWidget:
             try:
                 self.audio_stream.terminate()
             except Exception as exc:
-                print(f"Error terminating audio stream: {exc}")
+                logger.warning("Error terminating audio stream: %s", exc)
             finally:
                 self.audio_stream = None

--- a/widgets/collapsable_layer.py
+++ b/widgets/collapsable_layer.py
@@ -6,6 +6,7 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 import contextlib
+import logging
 import re
 
 import cv2
@@ -28,6 +29,8 @@ import dnnlib
 from utils.gui_utils import imgui_utils, gl_utils
 from utils.resource_paths import resource_path
 from widgets import osc_menu
+
+logger = logging.getLogger(__name__)
 from assets.colors import *
 
 # ----------------------------------------------------------------------------
@@ -54,7 +57,7 @@ def open_path(trans):
         else:
             trans.cluster_config = None
     except Exception as e:
-        print(e)
+        logger.warning("Failed to load cluster config: %s", e)
         trans.cluster_config = None
 
 
@@ -107,7 +110,6 @@ class LayerWidget:
 
         self.transform_img = cv2.imread(str(resource_path("assets", "transformation.png")))
         self.transform_img = cv2.cvtColor(self.transform_img, cv2.COLOR_BGR2RGBA)
-        print("UNIQUES", np.unique(self.transform_img))
 
         self.transform_img[:, :, 3] = np.where(self.transform_img[:, :, 0] == 255, 255, 0)
         self.transform_texture = gl_utils.Texture(image=self.transform_img, width=self.transform_img.shape[1],
@@ -126,33 +128,22 @@ class LayerWidget:
             self.tab, self.img_scale_db, self.img_normalize
 
     def set_params(self, param):
-        print(1)
         self.mode = param[0]
-        print(2)
         self.names = param[2]
-        print(3)
         self.ratios = param[6]
-        print(4)
         self.capture_layer = param[9]
-        print(5)
         self.capture_channels = param[10]
-        print(6)
         self.tab = param[11]
-        print(7)
         self.img_scale_db = param[12]
-        print(8)
         self.img_normalize = param[13]
-        print(9)
         self.mode, cached_transforms, self.names, self.has_transforms, cached_adjustments, noises, self.ratios, self.paths, self.imgui_ids, self.capture_layer, self.capture_channels, self.tab, self.img_scale_db, self.img_normalize = param
-        print("success")
         for i, trans in enumerate(self.cached_transforms):
             for j in range(len(trans.params)):
                 try:
                     self.viz.osc_dispatcher.unmap(f"/{trans.osc_address[j]}",
                                                   self.transform_osc(trans, param_idx=j))
-                except Exception as e:
-                    print(e)
-                    print(f"{trans.osc_address[j]} is not mapped")
+                except Exception:
+                    logger.warning("OSC address %s is not mapped", trans.osc_address[j])
 
         self.cached_transforms = cached_transforms
         for i, trans in enumerate(self.cached_transforms):
@@ -165,9 +156,8 @@ class LayerWidget:
             try:
                 self.viz.osc_dispatcher.unmap(f"/{noise['osc_address']}",
                                               self.noise_osc(noise))
-            except Exception as e:
-                print(e)
-                print(f"{noise['osc_address']} is not mapped")
+            except Exception:
+                logger.warning("OSC address %s is not mapped", noise['osc_address'])
         self.noises = noises
         for _, noise in self.noises.items():
             if noise["use_osc"] and noise["osc_address"]:
@@ -369,7 +359,6 @@ class LayerWidget:
 
                         self.has_transforms[layer.name] = False
             else:
-                print([layer.name for layer in layers])
                 for layer in layers:
                     if 'conv' in layer.name or "torgb" in layer.name:
                         draw_list.channels_split(2)
@@ -722,12 +711,8 @@ class LayerWidget:
                                             try:
                                                 self.viz.osc_dispatcher.unmap(f"/{trans.osc_address[j]}",
                                                                               self.osc_funcs[trans.imgui_id][j])
-                                                print(f"Unmapped", trans.osc_address[j])
-                                                print(self.viz.osc_dispatcher.mappings)
-                                            except Exception as e:
-                                                print(f"{trans.osc_address[j]} is not mapped")
-                                                print(e)
-                                                print(self.viz.osc_dispatcher._map)
+                                            except Exception:
+                                                logger.warning("OSC address %s is not mapped", trans.osc_address[j])
                                             self.viz.osc_dispatcher.map(f"/{address}",
                                                                         self.osc_funcs[trans.imgui_id][j])
                                             trans.osc_address[j] = address
@@ -779,8 +764,8 @@ class LayerWidget:
                     if c_dict['cluster_index'] == int(trans.cluster_ID):
                         indices.append(c_dict['feature_index'])
                 if len(indices) == 0:
-                    print("No indicies found for clusterID: " + str(trans.cluster_ID) + " on layer: " + str(
-                        trans.layerID))
+                    logger.warning("No indices found for cluster %s on layer %s",
+                                   trans.cluster_ID, trans.layerID)
                 trans.indices = indices
         imgui.separator()
         imgui.end_group()
@@ -823,8 +808,8 @@ class LayerWidget:
                             try:
                                 self.viz.osc_dispatcher.unmap(f"/{noise['osc_address']}",
                                                               self.noise_osc(noise))
-                            except:
-                                print(f"{noise['osc_address']} is not mapped")
+                            except Exception:
+                                logger.warning("OSC address %s is not mapped", noise['osc_address'])
                             self.viz.osc_dispatcher.map(f"/{address}",
                                                         self.noise_osc(noise))
                             noise["osc_address"] = address

--- a/widgets/help_icon_widget.py
+++ b/widgets/help_icon_widget.py
@@ -1,7 +1,11 @@
+import logging
+
 import pandas as pd
 import imgui
 import webbrowser
 from utils.resource_paths import get_version, resource_path
+
+logger = logging.getLogger(__name__)
 
 DOCS_BASE_URL = f"https://metacreation-lab.github.io/autolume/{get_version()}"
 
@@ -31,7 +35,7 @@ class HelpIconWidget:
                             raw_url = str(row['url']).strip()
                             help_urls[key] = self._resolve_docs_url(raw_url)
         except Exception as e:
-            print(f"Error loading help texts: {e}")
+            logger.warning("Error loading help texts: %s", e)
 
         return help_texts, help_urls
 

--- a/widgets/image_preview_widget.py
+++ b/widgets/image_preview_widget.py
@@ -1,7 +1,10 @@
 import os
 import cv2
+import logging
 import numpy as np
 from utils.gui_utils import gl_utils
+
+logger = logging.getLogger(__name__)
 import imgui
 
 from utils.dataset_preprocessing_utils import DatasetPreprocessingUtils
@@ -42,7 +45,7 @@ class ImagePreviewWidget:
                 self._update_texture(img)
                 
         except Exception as e:
-            print(f"Error processing image for preview: {e}")
+            logger.warning("Error processing image for preview: %s", e)
             return
     
     def _update_texture(self, img):
@@ -101,4 +104,4 @@ class ImagePreviewWidget:
             self.image_shape = None
             
         except Exception as e:
-            print(f"Warning: Error during image preview widget cleanup: {e}")
+            logger.warning("Error during image preview widget cleanup: %s", e)

--- a/widgets/latent_widget.py
+++ b/widgets/latent_widget.py
@@ -8,11 +8,14 @@
 import copy
 import os
 
+import logging
 import numpy as np
 import torch
 import torch.nn.functional as F
 
 from widgets.native_browser_widget import NativeBrowserWidget
+
+logger = logging.getLogger(__name__)
 
 try:
     import cPickle as pickle
@@ -57,7 +60,6 @@ class LatentWidget:
 
     def save(self, path):
         with open(path, "wb") as f:
-            print(self.get_params())
             pickle.dump(self.get_params(), f)
 
     def load(self, path):
@@ -187,11 +189,10 @@ class LatentWidget:
             path = self.browser.select_vector_file(initial_dir=self.vec_path)
             if path:
                 self.vec_path = str(path)
-                print("Selected vector at", self.vec_path)
 
         imgui.same_line()
         if imgui_utils.button("Load##vecmode", width=viz.app.button_w, enabled=self.vec_path is not None and self.vec_path != ''):
-            print("Loading vector from", self.vec_path)
+            logger.info("Loading vector from %s", self.vec_path)
             if self.vec_path:
                 if self.vec_path.endswith('.npy'):
                     self.latent.vec = torch.from_numpy(np.load(self.vec_path))
@@ -202,8 +203,8 @@ class LatentWidget:
                     if len(self.latent.vec.shape) == 1:
                         self.latent.vec = self.latent.vec.unsqueeze(0)
                 else:
-                    print("Unsupported file format")
-                print("Loaded vector of shape", self.latent.vec.shape)
+                    logger.warning("Unsupported vector file format: %s", self.vec_path)
+                logger.debug("Loaded vector of shape %s", self.latent.vec.shape)
                 self.latent.next = torch.randn(self.latent.next.shape)
 
 
@@ -259,7 +260,7 @@ class LatentWidget:
                 if isinstance(value, (int, float)):
                     index = round(value)
                     if index < 0 or index >= len(pickle_widget.browse_cache):
-                        print(f"OSC model: index {index} out of range (0-{len(pickle_widget.browse_cache) - 1})")
+                        logger.warning("OSC model: index %d out of range (0-%d)", index, len(pickle_widget.browse_cache) - 1)
                         return
                     target = pickle_widget.browse_cache[index]
                 elif isinstance(value, str):
@@ -274,7 +275,7 @@ class LatentWidget:
                                 target = path
                                 break
                     if target is None:
-                        print(f"OSC model: no model matching '{value}' found")
+                        logger.warning("OSC model: no model matching '%s' found", value)
                         return
                 else:
                     return

--- a/widgets/layer_widget.py
+++ b/widgets/layer_widget.py
@@ -11,6 +11,7 @@ except ModuleNotFoundError:
     import pickle
 
 import copy
+import logging
 import os
 import random
 
@@ -21,6 +22,8 @@ import yaml
 
 import dnnlib
 from utils.gui_utils import imgui_utils
+
+logger = logging.getLogger(__name__)
 
 # ----------------------------------------------------------------------------
 
@@ -46,7 +49,7 @@ def open_path(trans):
         else:
             trans.cluster_config = None
     except Exception as e:
-        print(e)
+        logger.warning("Failed to load cluster config: %s", e)
         trans.cluster_config = None
 
 
@@ -87,9 +90,8 @@ class LayerWidget:
                 try:
                     self.viz.osc_dispatcher.unmap(f"/{trans.osc_address[j]}",
                                                   self.transform_osc(trans, param_idx=j))
-                except Exception as e:
-                    print(e)
-                    print(f"{trans.osc_address[j]} is not mapped")
+                except Exception:
+                    logger.warning("OSC address %s is not mapped", trans.osc_address[j])
 
         self.cached_transforms = cached_transforms
         for i, trans in enumerate(self.cached_transforms):
@@ -102,9 +104,8 @@ class LayerWidget:
             try:
                 self.viz.osc_dispatcher.unmap(f"/{noise['osc_address']}",
                                               self.noise_osc(noise))
-            except Exception as e:
-                print(e)
-                print(f"{noise['osc_address']} is not mapped")
+            except Exception:
+                logger.warning("OSC address %s is not mapped", noise['osc_address'])
         self.noises = noises
         for _, noise in self.noises.items():
             if noise["use_osc"] and noise["osc_address"]:
@@ -392,12 +393,8 @@ class LayerWidget:
                                             try:
                                                 self.viz.osc_dispatcher.unmap(f"/{trans.osc_address[j]}",
                                                                               self.osc_funcs[trans.imgui_id][j])
-                                                print(f"Unmapped",trans.osc_address[j])
-                                                print(self.viz.osc_dispatcher.mappings)
-                                            except Exception as e:
-                                                print(f"{trans.osc_address[j]} is not mapped")
-                                                print(e)
-                                                print(self.viz.osc_dispatcher._map)
+                                            except Exception:
+                                                logger.warning("OSC address %s is not mapped", trans.osc_address[j])
                                             self.viz.osc_dispatcher.map(f"/{address}",
                                                                         self.osc_funcs[trans.imgui_id][j])
                                             trans.osc_address[j] = address
@@ -458,8 +455,8 @@ class LayerWidget:
                     if c_dict['cluster_index'] == int(trans.cluster_ID):
                         indices.append(c_dict['feature_index'])
                 if len(indices) == 0:
-                    print("No indicies found for clusterID: " + str(trans.cluster_ID) + " on layer: " + str(
-                        trans.layerID))
+                    logger.warning("No indices found for cluster %s on layer %s",
+                                   trans.cluster_ID, trans.layerID)
                 trans.indices = indices
         imgui.separator()
         imgui.end_group()
@@ -501,8 +498,8 @@ class LayerWidget:
                             try:
                                 self.viz.osc_dispatcher.unmap(f"/{noise['osc_address']}",
                                                               self.noise_osc(noise))
-                            except:
-                                print(f"{noise['osc_address']} is not mapped")
+                            except Exception:
+                                logger.warning("OSC address %s is not mapped", noise['osc_address'])
                             self.viz.osc_dispatcher.map(f"/{address}",
                                                         self.noise_osc(noise))
                             noise["osc_address"] = address

--- a/widgets/looping_widget.py
+++ b/widgets/looping_widget.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 import os
 
 import imgui
@@ -13,6 +14,7 @@ except ModuleNotFoundError:
 
 import dnnlib
 from utils import device_utils
+from utils.app_logging import LoggedProcess
 from utils.gui_utils import imgui_utils
 from widgets import osc_menu
 from widgets.native_browser_widget import NativeBrowserWidget
@@ -20,6 +22,8 @@ from widgets.native_browser_widget import NativeBrowserWidget
 from pythonosc.udp_client import SimpleUDPClient
 
 import multiprocessing as mp
+
+logger = logging.getLogger(__name__)
 
 
 def valmap(value, istart, istop, ostart, ostop):
@@ -124,7 +128,7 @@ class LoopingWidget:
         self.noise_loop_feats = [OSN(self.noise_seed + i, self.radius) for i in range(512)]
         self.args_queue = mp.Queue()
         self.results_queue = mp.Queue()
-        self.noise_loop_process = mp.Process(target=noise_loop, args=(self.args_queue, self.results_queue), daemon=True)
+        self.noise_loop_process = LoggedProcess(target=noise_loop, args=(self.args_queue, self.results_queue), daemon=True, name='noise-loop')
         self.noise_loop_process.start()
 
         # flag that tells us we need to stop loop necessary for reverse looping
@@ -165,7 +169,6 @@ class LoopingWidget:
                 assert (type(args[-1]) is type(
                     self.alpha)), f"OSC Message and Parameter type must align [OSC] {type(args[-1])} != [Param] {type(self.alpha)}"
                 self.alpha = args[-1]
-                print(self.alpha, args[-1])
                 self.update_alpha()
 
             except Exception as e:
@@ -233,7 +236,6 @@ class LoopingWidget:
 
         if self.alpha >= 1:
             if self.halt_update < 0:
-                print(self.params.index, self.params.num_keyframes, self.loop_type)
                 if self.params.index == (self.params.num_keyframes - 1) or self.loop_type is False:
                     self.looped = 1
                     if self.perfect_loop:
@@ -286,7 +288,6 @@ class LoopingWidget:
 
     def open_vec(self, idx):
         try:
-            print(self.paths[idx])
             # if file ends with pt or pth, load as torch tensor else if ends with npy, load as numpy array and convert to torch tensor
             if self.paths[idx].endswith(".pt") or self.paths[idx].endswith(".pth"):
                 vec = torch.load(self.paths[idx]).squeeze()
@@ -297,10 +298,9 @@ class LoopingWidget:
                     "Filetype not supported, please use .pt, .pth or .npy files for loading vectors, if you are using a .npy file, please ensure that it is a numpy array")
             assert vec.shape[-1] == self.keyframes[
                 idx].shape[-1], f"The Tensor you are loading has a different shape, Loaded Shape {vec.shape} != Target Shape {self.keyframes[idx].shape}"
-            print("LOADed VEC", vec.shape, torch.unique(vec))
             self.keyframes[idx] = vec
-        except Exception as e:
-            print(e)
+        except Exception:
+            logger.exception("Failed to load vector %s", self.paths[idx])
 
     def vec_viz(self, idx):
         viz = self.viz
@@ -329,8 +329,6 @@ class LoopingWidget:
                 elif snapped["mode"] == 2:
                     self.looping_snaps[idx] = snapped["snap"]
                     self.modes[idx] = snapped["mode"]
-                    print(self.looping_snaps[idx])
-                    print(self.modes[idx])
 
         imgui.same_line()
         if imgui_utils.button(f"Randomize##vecmode{idx}", width=viz.app.button_w):
@@ -368,23 +366,17 @@ class LoopingWidget:
         imgui.same_line()
         if imgui_utils.button(f"Snap##seed{idx}", viz.app.button_w):
             snapped = self.snap()
-            print("snapped", snapped, "-----------------------")
 
             if not (snapped is None):
                 if snapped["mode"] == 0:
-                    print("SEED")
                     self.seeds[idx] = snapped["snap"]  # [snapped["snap"]["x"],snapped["snap"]["y"]]
                     self.modes[idx] = snapped["mode"]
                 elif snapped["mode"] == 1:
-                    print("VECTOR")
                     self.keyframes[idx] = snapped["snap"]
                     self.modes[idx] = snapped["mode"]
                 elif snapped["mode"] == 2:
-                    print("getting LOOP")
                     self.looping_snaps[idx] = snapped["snap"]
                     self.modes[idx] = snapped["mode"]
-                    print(self.looping_snaps[idx])
-                    print(self.modes[idx])
         imgui.same_line()
         if imgui_utils.button(f"Remove##vecmode{idx}", width=viz.app.button_w):
             self.remove_entry = idx
@@ -398,7 +390,7 @@ class LoopingWidget:
             try:
                 self.osc_client.send_message(self.osc_address, self.looped)
             except Exception as e:
-                print(e)
+                logger.warning("OSC send failed: %s", e)
         viz = self.viz
         # viz.args.looping = self.params.anim
 
@@ -463,14 +455,10 @@ class LoopingWidget:
                                                                                                 self.params.num_keyframes)]
                     self.project = project
                     looping_snaps = [{} for _ in range(new_keyframes)]
-                    print("empty looping_snaps", len(looping_snaps))
                     looping_snaps[:min(new_keyframes, self.params.num_keyframes)] = self.looping_snaps[
                                                                                     :min(new_keyframes,
                                                                                          self.params.num_keyframes)]
-                    print(looping_snaps)
                     self.looping_snaps = looping_snaps
-                    print(self.looping_snaps, looping_snaps)
-                    print("Looping snaps add", len(self.looping_snaps), self.params.num_keyframes)
 
                     self.params.num_keyframes = new_keyframes
 
@@ -491,7 +479,6 @@ class LoopingWidget:
                             del self.seeds[self.remove_entry]
                             del self.looping_snaps[self.remove_entry]
 
-                            print("Looping snaps del", len(self.looping_snaps), self.params.num_keyframes)
                             self.params.num_keyframes -= 1
                             self.remove_entry = -1
 
@@ -559,7 +546,6 @@ class LoopingWidget:
                         elif mode == 1:
                             l_list.append({"mode": "vec", "latent": self.keyframes[i], "project": self.project[i]})
                         elif mode == 2:
-                            print("adding loop", self.looping_snaps[i])
                             l_list.append({"mode": "loop", "looping_list": self.looping_snaps[i]["looping_list"],
                                            "looping_index": self.looping_snaps[i]["index"],
                                            "alpha": self.looping_snaps[i]["alpha"]})

--- a/widgets/mixing_widget.py
+++ b/widgets/mixing_widget.py
@@ -31,7 +31,6 @@ def extract_mapping_names(model):
     return model_names
 
 def resolve_pkl(pattern):
-        print("RESOLVE", pattern)
         assert isinstance(pattern, str)
         assert pattern != ''
 
@@ -95,7 +94,6 @@ class MixingWidget:
             if imgui_utils.button("Find##mixpkl", width=self.viz.app.button_w):
                 pkl = self.browser.select_model_file(initial_dir=self.model_pth)
                 if pkl:
-                    print("SELECTED", pkl)
                     self.model_pth = resolve_pkl(str(pkl))
                     model_changed = True
             
@@ -107,7 +105,6 @@ class MixingWidget:
             imgui.text(".pkl")
             imgui.same_line()
             if imgui_utils.button("Save##mixing widget", enabled=self.output_name != ""):
-                print("saving at", self.output_name)
                 self._save = True
             
             imgui.separator()
@@ -118,7 +115,6 @@ class MixingWidget:
                 if self.viz.args.pkl != self.main_model or model_changed or layers1 != self.layer1 or layers2 != self.layer2:
                     self.layer1 = layers1
                     self.layer2 = layers2
-                    print("reinitatilzation")
                     self.main_model = self.viz.args.pkl
                     self.combined_layers = ["A"] * len(layers1)
                     if len(layers2) > len(layers1):
@@ -205,7 +201,6 @@ class MixingWidget:
                     with imgui_utils.grayed_out(l1 == '' or ckb_display == "X"):
                         clicked, _ = imgui.checkbox(f"##layer1{i}", (ckb_display == "A" or ckb_display == "Mixed") and layer1[i] != '')
                     if clicked and layer1[i] != '' and ckb_display != "X":
-                        print("clicked1")
                         self.combined_layers[i] = "A"
                         for j in range(i + 1, len(self.combined_layers)):
                             if layer1[j]:
@@ -216,7 +211,6 @@ class MixingWidget:
                     with imgui_utils.grayed_out(l2=='' or ckb_display == "X"):
                         clicked, _ = imgui.checkbox(f"##layer2{i}", ckb_display == "B" or ckb_display == "Mixed" and layer2[i] != '')
                     if clicked and layer2[i] != ''and ckb_display != "X":
-                        print("clicked2")
                         self.combined_layers[i] = "B"
                         for j in range(i + 1, len(self.combined_layers)):
                             if layer2[j]:
@@ -281,14 +275,12 @@ class MixingWidget:
                             with imgui_utils.grayed_out(l1t == '' or self.combined_layers[it]=="X"):
                                 clicked, _ = imgui.checkbox(f"##layer1{i}{it}", self.combined_layers[it] == "A")
                             if clicked and l1t != '' and not(self.combined_layers[it]=="X"):
-                                print("clicked1")
-                                self.combined_layers[it] = "A"
+                                        self.combined_layers[it] = "A"
                             imgui.same_line((imgui.get_content_region_available_width() // 3 * 2) + imgui.get_style().scrollbar_size - imgui.get_style().item_spacing[0])
                             with imgui_utils.grayed_out(l2t == '' or self.combined_layers[it]=="X"):
                                 clicked, _ = imgui.checkbox(f"##layer2{i}{it}", self.combined_layers[it]=="B")
                             if clicked and l2t != '' and not(self.combined_layers[it]=="X"):
-                                print("clicked2")
-                                self.combined_layers[it] = "B"
+                                        self.combined_layers[it] = "B"
 
                 imgui.end_child()
                 res_exp += 1

--- a/widgets/native_browser_widget.py
+++ b/widgets/native_browser_widget.py
@@ -6,6 +6,7 @@ pywin32 on Windows, zenity/kdialog on Linux. tkinter is not used; Tk cannot
 run inside this process on macOS because GLFW owns the NSApplication.
 """
 
+import logging
 import os
 import sys
 from typing import List, Optional, Tuple
@@ -16,6 +17,8 @@ except ImportError:
     # On Linux without zenity/kdialog, filedialpy falls back to tkinter at
     # import time, which may be unavailable. Degrade to no-op dialogs.
     filedialpy = None
+
+logger = logging.getLogger(__name__)
 
 
 class NativeBrowserWidget:
@@ -65,8 +68,8 @@ class NativeBrowserWidget:
     @staticmethod
     def _dialogs_available() -> bool:
         if filedialpy is None:
-            print("Native file dialogs unavailable: filedialpy could not be imported "
-                  "(on Linux, install zenity or kdialog)")
+            logger.warning("Native file dialogs unavailable: filedialpy could not be imported "
+                           "(on Linux, install zenity or kdialog)")
             return False
         return True
 
@@ -107,7 +110,7 @@ class NativeBrowserWidget:
             paths = filedialpy.openFiles(title=title, filter=self._filter_arg(patterns),
                                          initial_dir=self._resolve_initial_dir(initial_dir))
         except Exception as e:
-            print(f"Native file dialog failed: {e}")
+            logger.error("Native file dialog failed: %s", e)
             return []
         if isinstance(paths, str):
             paths = [paths] if paths else []
@@ -122,7 +125,7 @@ class NativeBrowserWidget:
         try:
             path = filedialpy.openDir(title=title, initial_dir=self._resolve_initial_dir(initial_dir))
         except Exception as e:
-            print(f"Native directory dialog failed: {e}")
+            logger.error("Native directory dialog failed: %s", e)
             return None
         if not path or not os.path.isdir(path):
             return None
@@ -140,7 +143,7 @@ class NativeBrowserWidget:
             path = filedialpy.openFile(title=title, filter=self._filter_arg(patterns),
                                        initial_dir=self._resolve_initial_dir(initial_dir))
         except Exception as e:
-            print(f"Native file dialog failed: {e}")
+            logger.error("Native file dialog failed: %s", e)
             return None
         # The macOS backend maps a cancelled dialog to the current directory.
         if not path or not os.path.isfile(path):
@@ -156,7 +159,7 @@ class NativeBrowserWidget:
             path = filedialpy.saveFile(title=title, filter=self._filter_arg(patterns),
                                        initial_dir=self._resolve_initial_dir(initial_dir), initial_file=initial_file)
         except Exception as e:
-            print(f"Native save dialog failed: {e}")
+            logger.error("Native save dialog failed: %s", e)
             return None
         if not path:
             return None
@@ -188,7 +191,7 @@ class NativeBrowserWidget:
         try:
             return [f for f in os.listdir(directory) if os.path.isfile(os.path.join(directory, f))]
         except (OSError, PermissionError) as e:
-            print(f"Error reading directory {directory}: {e}")
+            logger.warning("Error reading directory %s: %s", directory, e)
             return []
 
     def _filter_files_by_type(self, files: List[str], file_type: str = "image") -> List[str]:
@@ -249,7 +252,7 @@ class NativeBrowserWidget:
                         video_files.append(os.path.join(root, file))
                         has_video_files = True
         except (OSError, PermissionError) as e:
-            print(f"Error scanning directory {directory_path}: {e}")
+            logger.warning("Error scanning directory %s: %s", directory_path, e)
             return directory_path, False, []
 
         return directory_path, has_video_files, video_files

--- a/widgets/osc_menu.py
+++ b/widgets/osc_menu.py
@@ -1,9 +1,12 @@
 import contextlib
 
+import logging
 import imgui
 
 import dnnlib
 from utils.gui_utils import imgui_utils
+
+logger = logging.getLogger(__name__)
 import numpy as np
 import math
 import torch
@@ -50,7 +53,7 @@ class OscMenu:
                 try:
                     func(*args, **kwargs)
                 except Exception as e:
-                    print(e)
+                    logger.warning("OSC handler failed: %s", e)
 
         return wrapper
 
@@ -60,7 +63,7 @@ class OscMenu:
                 f = lambda x: eval(self.mappings[key])
                 func(args[0], f(args[-1]))
             except Exception as e:
-                print(e)
+                logger.warning("OSC mapping failed, forwarding raw args: %s", e)
                 func(*args)
 
         return wrapper
@@ -79,8 +82,8 @@ class OscMenu:
                 viz.osc_dispatcher.map(f"/{self.osc_addresses[key]}", self.wrapped_funcs[key])
                 try:
                     viz.osc_dispatcher.unmap(f"/{self.cached_osc_addresses[key]}", self.wrapped_funcs[key])
-                except:
-                    print(self.cached_osc_addresses[key], "is not mapped")
+                except Exception:
+                    logger.warning("OSC address %s is not mapped", self.cached_osc_addresses[key])
                 self.cached_osc_addresses[key] = self.osc_addresses[key]
             if self.use_map.get(key, False):
                 changed, self.mappings[key] = imgui.input_text(f"##Mappings_{self.label}_{key}",
@@ -91,8 +94,8 @@ class OscMenu:
                 if changed:
                     try:
                         viz.osc_dispatcher.unmap(f"/{self.osc_addresses[key]}", self.wrapped_funcs[key])
-                    except:
-                        print(self.cached_osc_addresses[key], "is not mapped")
+                    except Exception:
+                        logger.warning("OSC address %s is not mapped", self.cached_osc_addresses[key])
                     self.wrapped_funcs[key] = self.map_func(self.funcs[key], key)
                     viz.osc_dispatcher.map(f"/{self.osc_addresses[key]}", self.wrapped_funcs[key])
 

--- a/widgets/performance_widget.py
+++ b/widgets/performance_widget.py
@@ -7,6 +7,7 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
 import array
+import logging
 import threading
 
 import numpy as np
@@ -17,6 +18,8 @@ from utils import device_utils
 from utils.gui_utils import imgui_utils
 from pythonosc.osc_server import BlockingOSCUDPServer
 from pythonosc.udp_client import SimpleUDPClient
+
+logger = logging.getLogger(__name__)
 try:
     import NDIlib as ndi
 except ImportError:
@@ -50,9 +53,9 @@ class PerformanceWidget:
             self.viz.server_thread = threading.Thread(target=self.viz.server.serve_forever, daemon=True)
             self.viz.server_thread.start()
             self.viz.osc_client = SimpleUDPClient(self.viz.in_ip, self.viz.in_port)
-            print(f"OSC server started on {self.viz.in_ip}:{self.viz.in_port}")
+            logger.info("OSC server started on %s:%s", self.viz.in_ip, self.viz.in_port)
         except Exception as e:
-            print(f"Failed to start OSC server: {e}")
+            logger.error("Failed to start OSC server: %s", e)
 
 
     @imgui_utils.scoped_by_object_id
@@ -126,9 +129,9 @@ class PerformanceWidget:
                 self.viz.server_thread.join()
                 try:
                     self.viz.server = BlockingOSCUDPServer((self.viz.in_ip, self.viz.in_port), self.viz.osc_dispatcher)
-                except:
-                    print("Please input a valid ip address")
-                print("new server", self.viz.in_ip, self.viz.in_port)
+                except Exception:
+                    logger.error("Invalid OSC server address %s:%s", self.viz.in_ip, self.viz.in_port)
+                logger.info("OSC server restarted on %s:%s", self.viz.in_ip, self.viz.in_port)
                 self.viz.server_thread = threading.Thread(target=self.viz.server.serve_forever, daemon=True)
                 self.viz.server_thread.start()
                 self.viz.osc_client = SimpleUDPClient(self.viz.in_ip, self.viz.in_port)

--- a/widgets/pickle_widget.py
+++ b/widgets/pickle_widget.py
@@ -7,6 +7,7 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
 import glob
+import logging
 import os
 import re
 
@@ -24,6 +25,8 @@ from widgets.native_browser_widget import NativeBrowserWidget
 from widgets.model_download_widget import ModelDownloadWidget, ModelDropdownButton
 
 from . import renderer
+
+logger = logging.getLogger(__name__)
 
 #----------------------------------------------------------------------------
 
@@ -70,7 +73,6 @@ class PickleWidget:
     def load_pkl(self, pkl, ignore_errors=False):
         viz = self.viz
         viz.app.skip_frame() # The input field will change on next frame.
-        print(os.getcwd())
         try:
             resolved = self.resolve_pkl(pkl)
             name = resolved.replace('\\', '/').split('/')[-1]
@@ -103,20 +105,20 @@ class PickleWidget:
             if os.path.exists(os.path.join(models_dir(), tail)):
                 self.user_pkl = os.path.join(models_dir(), tail)
             else:
-                print('ERROR: Model does not exist in the model folder.')
+                logger.error("Model does not exist in the model folder")
         if not os.path.exists(self.cur_pkl):
             head, tail = os.path.split(self.cur_pkl)
             if os.path.exists(os.path.join(models_dir(), tail)):
                 self.cur_pkl = os.path.join(models_dir(), tail)
             else:
-                print('ERROR: Model does not exist in the model folder.')
+                logger.error("Model does not exist in the model folder")
         for recent_pkl in self.recent_pkls:
             if not os.path.exists(self.recent_pkl):
                 head, tail = os.path.split(self.recent_pkl)
                 if os.path.exists(os.path.join(models_dir(), tail)):
                     self.cur_pkl = os.path.join(models_dir(), tail)
                 else:
-                    print('ERROR: Model does not exist in the model folder.')
+                    logger.error("Model does not exist in the model folder")
         
 
 
@@ -142,7 +144,6 @@ class PickleWidget:
             if imgui_utils.button("Find##pkl", width=self.viz.app.button_w):
                 pkl = self.browser.select_model_file(initial_dir=self.user_pkl)
                 if pkl:
-                    print("SELECTED", pkl)
                     self.load_pkl(str(pkl), ignore_errors=True)
             imgui.same_line()
             picked = self.model_dropdown(width=-1)

--- a/widgets/preset_widget.py
+++ b/widgets/preset_widget.py
@@ -212,12 +212,15 @@
 #         self.load(self.paths[np.where(self.active)].item())
 
 
+import logging
 import os
 import imgui
 import numpy as np
 from utils.gui_utils import imgui_utils
 from utils.user_data import data_path
 from widgets.native_browser_widget import NativeBrowserWidget
+
+logger = logging.getLogger(__name__)
 
 class PresetWidget:
     def __init__(self, viz):
@@ -243,7 +246,6 @@ class PresetWidget:
                 self.active[i] = False
         self.tmp_path = self.path
         self.paths = np.asarray([f"{self.path}/{i}" for i in range(self.num_presets)], dtype=object)
-        print(self.dir_name)
         self.check_presets()
         self.recent_paths = [self.path]
         self.use_osc = False
@@ -292,10 +294,10 @@ class PresetWidget:
             self.active = np.append(self.active, False)
             self.paths = np.append(self.paths, new_folder_path)
             self.assigned = np.append(self.assigned, 1)
-            print(f"创建新文件夹: {new_folder_path}")
+            logger.info("Created preset folder %s", new_folder_path)
             self.check_presets()
         except Exception as e:
-            print(f"创建新文件夹时出错: {e}")
+            logger.error("Failed to create preset folder: %s", e)
 
     # def open_path(self, path):
     #     try:
@@ -346,13 +348,12 @@ class PresetWidget:
                         os.makedirs(os.path.join(path, self.dir_name[i]), exist_ok=True)
             
             self.paths = np.asarray([os.path.join(path, self.dir_name[i]) for i in range(self.num_presets)], dtype=object)
-            print('paths: ' + str(self.paths))
             self.path = path
             self.tmp_path = path
             self.check_presets()
             self.scroll_index = 0  # 重置滚动索引
-        except Exception as e:
-            print(f"Error in open_path: {e}")
+        except Exception:
+            logger.exception("Failed to open preset path %s", path)
 
 
     def save(self, path):
@@ -377,8 +378,8 @@ class PresetWidget:
             self.viz.collapsed_widget.save(os.path.join(path, "collap.pkl"))
             self.viz.mixing_widget.save(os.path.join(path, "mix.pkl"))
             self.assigned[np.where(self.active)] = 0
-        except Exception as e:
-            print(e)
+        except Exception:
+            logger.exception("Failed to save preset to %s", path)
 
     def load(self, path):
         try:
@@ -399,12 +400,12 @@ class PresetWidget:
             try: 
                 self.viz.pickle_widget.load(os.path.join(path, "pickle.pkl"))
             except Exception as e:
-                print(f"Ignored error while loading pickle.pkl: {e}")
+                logger.warning("Ignored error while loading pickle.pkl: %s", e)
             self.viz.collapsed_widget.load(f"{path}/collap.pkl")
             self.viz.mixing_widget.load(os.path.join(path, "mix.pkl"))
             self.viz.app.skip_frame()
-        except Exception as e:
-            print(e)
+        except Exception:
+            logger.exception("Failed to load preset from %s", path)
 
     @imgui_utils.scoped_by_object_id
     def preset_checkbox(self, i):
@@ -602,8 +603,8 @@ class PresetWidget:
                     try:
                         viz.osc_dispatcher.unmap(f"/{self.osc_addresses}", self.osc_handler)
                         self.osc_addresses = osc_address
-                    except:
-                        print(f"{self.osc_addresses} is not mapped")
+                    except Exception:
+                        logger.warning("OSC address %s is not mapped", self.osc_addresses)
                     viz.osc_dispatcher.map(f"/{self.osc_addresses}", self.osc_handler)
 
     def osc_handler(self, address, *args):

--- a/widgets/renderer.py
+++ b/widgets/renderer.py
@@ -8,6 +8,7 @@
 
 import sys
 import contextlib
+import logging
 import copy
 import time
 import traceback
@@ -29,6 +30,8 @@ from modules.network_mixing import extract_conv_names, extract_mapping_names
 from utils.model_dir import ensure_models_dir
 import os
 import pickle
+
+logger = logging.getLogger(__name__)
 
 super_res = SRVGGNetPlus(num_in_ch=3, num_out_ch=3, num_feat=48, upscale=4, act_type='prelu').eval().to(device_utils.get_device())
 model_sd=torch.load(str(resource_path('sr_models', 'Fast.pt')), map_location=device_utils.get_device())
@@ -283,17 +286,17 @@ class Renderer:
     def get_network(self, pkl, key, **tweak_kwargs):
         data = self._pkl_data.get(pkl, None)
         if data is None:
-            print(f'Loading "{pkl}"... ', end='', flush=True)
+            logger.info('Loading network pickle "%s"', pkl)
             if not self.checked_custom_kernel and torch.cuda.is_available():
-                print("Trying to compile custom cuda kernel, this can take a while...", flush=True)
+                logger.info("Trying to compile custom cuda kernel, this can take a while...")
             try:
                 with dnnlib.util.open_url(pkl, verbose=False) as f:
                     data = legacy.load_network_pkl(f, custom=True)
                     self.checked_custom_kernel = True
-                print('Done.')
+                logger.info('Loaded network pickle "%s"', pkl)
             except:
                 data = CapturedException()
-                print('Failed!')
+                logger.exception('Failed to load network pickle "%s"', pkl)
             self._pkl_data[pkl] = data
             self._ignore_timing()
         if isinstance(data, CapturedException):
@@ -303,7 +306,7 @@ class Renderer:
         cache_key = (orig_net, self._device, self.kernel_type, tuple(sorted(tweak_kwargs.items())))
         net = self._networks.get(cache_key, None)
         if net is None:
-            print(f'Initializing network "{cache_key}"... ', end='', flush=True)
+            logger.debug('Initializing network "%s"', cache_key)
             try:
                 net = copy.deepcopy(orig_net)
                 net = net.to(self._device).eval().requires_grad_(False)
@@ -311,8 +314,6 @@ class Renderer:
                 net = CapturedException()
             self._networks[cache_key] = net
             self._ignore_timing()
-        else:
-            print(f'Network "{cache_key}" already initialized, reusing... ', end='', flush=True)
         if isinstance(net, CapturedException):
             raise net
         return net
@@ -567,7 +568,7 @@ class Renderer:
                             if project:
                                 w = mapping_net(z=w, c=all_cs, truncation_psi=trunc_psi, truncation_cutoff=trunc_cutoff)
                         except Exception as e:
-                            print(e)
+                            logger.warning("Latent mapping failed: %s", e)
                     else:
                         w = self.to_device(vec.unsqueeze(0))
 
@@ -688,10 +689,6 @@ class Renderer:
                 use_G1 = False
             else:
                 raise ValueError("Last entry should be either A or B but is: ", last_entry)
-            print("CHANNELS", self.G.synthesis.channels_dict, self.G2.synthesis.channels_dict)
-            print("compare", len(self.combined_layers), len(self.G.synthesis.channels_dict), len(self.G2.synthesis.channels_dict))
-            print("layer1", layer1)
-            print("layer2", layer2)
 
             # create a new channel dict that takes the entrance of self.G.synthesis.channels_dict and self.G2.synthesis.channels_dict based on whether combined_layers is A or B
             new_channels_dict = {}
@@ -706,7 +703,6 @@ class Renderer:
                     pass
                 else:
                     raise ValueError("Entry should be either A or B but is: ", entry)
-            print("new_channels_dict", new_channels_dict)
 
             model_out = custom_stylegan2.Generator(z_dim=self.G.z_dim, w_dim=self.G.w_dim, c_dim=self.G.c_dim, img_channels=self.G.img_channels,
                                        img_resolution=img_resolution, synthesis_kwargs = {"channels_dict":new_channels_dict})
@@ -778,7 +774,7 @@ class Renderer:
                         try:
                             outputs = [self.manipulation(outputs[0], transform)]
                         except Exception as e:
-                            print(e)
+                            logger.warning("Network bending transform failed: %s", e)
 
             for idx, out in enumerate(outputs):
                 if out.ndim == 5:  # G-CNN => remove group dimension.
@@ -825,11 +821,6 @@ class Renderer:
     def process_loop(self, G, looping_list, looping_index, alpha, trunc_psi, trunc_cutoff):
         v0 = self.evaluate(G, looping_list[looping_index-1], trunc_psi, trunc_cutoff)
         v1 = self.evaluate(G, looping_list[looping_index], trunc_psi, trunc_cutoff)
-        print("v0", v0.shape, "v1", v1.shape)
-        print(v0)
-        print("v0 unique", torch.unique(v0))
-        print(v1)
-        print("v1 unique", torch.unique(v1))
         return slerp(alpha, v0, v1)
 
     def evaluate(self, G, keyframe, trunc_psi, trunc_cutoff):
@@ -843,14 +834,12 @@ class Renderer:
     def process_vec(self, G, latent, project, trunc_psi, trunc_cutoff):
         mapping_net = G.mapping
         latent = self.to_device(latent[None, ...])
-        print("WE ARE HERE", latent.shape)
         if project and len(latent.shape) == 2:
             all_cs = np.zeros([len(latent), G.c_dim], dtype=np.float32)
             latent = mapping_net(latent, all_cs, truncation_psi=trunc_psi,
                                truncation_cutoff=trunc_cutoff)
 
         if len(latent.shape) == 2:
-            print("TRYING TO REPEAT")
             latent = latent.repeat(G.num_ws, 1).unsqueeze(0)
 
         # if the latent isnt the right size i.e. in its second position it doesnt have the right number of ws either cut of the last ws or repeat the last ws

--- a/widgets/thumbnail_widget.py
+++ b/widgets/thumbnail_widget.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import math
 import collections
@@ -12,6 +13,8 @@ import PIL.Image
 import PIL.ImageOps
 
 from utils.gui_utils import gl_utils
+
+logger = logging.getLogger(__name__)
 from utils.dataset_preprocessing_utils import DatasetPreprocessingUtils
 
 # Threading and caching parameters
@@ -70,7 +73,7 @@ def _render_thumbnail(file_path, size, padding):
         canvas[y:y + h, x:x + w] = img
         return cv2.resize(canvas, (size, size), interpolation=cv2.INTER_AREA)
     except Exception as e:
-        print(f"Error rendering thumbnail for {file_path}: {e}")
+        logger.warning("Error rendering thumbnail for %s: %s", file_path, e)
         return None
 
 
@@ -324,7 +327,7 @@ class ThumbnailWidget:
             return gl_utils.Texture(image=data, width=data.shape[1],
                                     height=data.shape[0], channels=channels)
         except Exception as e:
-            print(f"Error creating thumbnail texture: {e}")
+            logger.warning("Error creating thumbnail texture: %s", e)
             return None
 
     def _evict(self):

--- a/widgets/trunc_noise_widget.py
+++ b/widgets/trunc_noise_widget.py
@@ -6,11 +6,14 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
+import logging
 import imgui
 
 import dnnlib
 from utils.gui_utils import imgui_utils
 from widgets import osc_menu
+
+logger = logging.getLogger(__name__)
 
 try:
     import cPickle as pickle
@@ -37,7 +40,7 @@ class TruncationNoiseWidget:
                 nec_type = type(self.params[param])
                 self.params[param] = nec_type(args[-1])
             except Exception as e:
-                print(e)
+                logger.warning("OSC handler failed: %s", e)
         return func
 
     def get_params(self):


### PR DESCRIPTION
## Summary

Adds real, full logging to Autolume: every process (main GUI, all spawned workers, pool workers) now logs into a daily-rotating `<data_root>/logs/autolume.log` (14-day retention), in both dev and PyInstaller-frozen mode.

Details:

- New `utils/app_logging.py`: the main process owns the single rotating file handler, drained by a `QueueListener`; all processes log through a shared queue (`QueueHandler`), so rotation is safe on Windows and disk I/O stays off the GUI thread.
- `LoggedProcess` (drop-in `multiprocessing.Process`) wires logging into all 8 worker types; `multiprocessing.Pool` workers use a logging initializer.
- stdout/stderr are redirected into the log in every process — captures vendored `dnnlib`/`torch_utils` prints and third-party output, and fixes output being lost entirely in windowed bundles.
- `sys.excepthook`/`threading.excepthook` log uncaught exceptions; `faulthandler` writes native crashes (CUDA aborts, segfaults) to an append-only `logs/crashes.log`; `main.py` wraps the torch import and app loop so fatal startup errors are always captured.
- Full first-party print sweep: errors → `logger.error/exception`, lifecycle → `info`, diagnostics → `debug`; per-frame and interaction-trace noise deleted. Vendored code untouched (covered by the stdout capture). Log level overridable via `AUTOLUME_LOG_LEVEL`.
- Per-run training `log.txt` in the run directory is kept alongside the central log.

## Type of change

- [x] Feature

## How was this tested?

- All changed files compile; grep gates confirm no live `print(` or `traceback.print_exc` remain in first-party code.
- Headless multiprocess test: parent, `LoggedProcess` child, and Pool worker log lines (with correct `processName`), stdout/stderr capture, a child crash traceback with exit code 1, and `crashes.log` creation all verified in `autolume.log`.
- macOS, dev mode (`uv run main.py`): navigated the menu and ran a training start-to-tick workflow.
- macOS, frozen `Autolume.app`: ran the exact same workflow and diffed the two logs — line-for-line identical except the `frozen=True` banner flag and warning source-context lines (unavailable inside the bundle by nature).

Needs human verification on other platforms:

- Windows frozen build: app launches with **no console window**, log fills identically to a dev run; run each worker workflow (render, training, dataset preprocessing incl. non-square tool, super-res, projection, GANSpace PCA, noise loop) and confirm named process lines appear; watch for brief console flashes during first-run CUDA op JIT compilation (cosmetic, can be suppressed later if seen).
- Rotation across midnight on Windows (no "file in use" errors).
- Changing the data folder in Settings: logs move to the new location after restart.

## Checklist

- [x] PR title follows Conventional Commits without a scope (`<type>: <subject>`)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Documentation in `docs/` or `README.md` is updated if user-visible behavior changed (no end-user docs describe logging/console behavior)
- [x] If this PR adds new runtime files, they are included in `release.py` (`utils/app_logging.py` is ordinary package code; the `logs/` directory is created at runtime — no `release.py` data changes needed; the Windows `--windowed` switch is part of this PR)
- [ ] Screenshots or a short clip are attached for UI changes (no UI changes)