### PR TITLE
fix: keep ui scale and text sharpness consistent across displays

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@ autolume/
 - [main.py](main.py) — entry point; wires the UI and rendering pipeline.
 - [pyproject.toml](pyproject.toml) — pinned dependencies; `torch==2.8.0+cu128` is a hard requirement, do not relax it.
 - [release.py](release.py) — cross-platform release script (`uv run release.py`); detects the host OS, resolves package locations via `importlib`, and assembles the PyInstaller `--add-binary`/`--add-data` flags per platform, then copies `sr_models/` and creates runtime dirs. **This is where to add new runtime files** — the auto-generated `Autolume.spec` is gitignored and rebuilt every release. Windows/Linux bundle the runtime JIT toolchain (torch headers/libs, ninja); macOS skips it (ops fall back to reference PyTorch on MPS) and produces `Autolume.app`.
+- [utils/user_data.py](utils/user_data.py) — user preferences and writable data paths. Preferences (data root, UI font size, …) persist to a JSON file at `~/.config/autolume/config.json` (`XDG_CONFIG_HOME` honored); the Settings modal ([modules/settings.py](modules/settings.py)) is their UI. **Add new user-facing preferences here** (a `pref()`/`set_pref()` accessor pair following the existing ones), not as ad-hoc files.
+- [utils/gui_utils/dpi.py](utils/gui_utils/dpi.py) — all display-scale math (monitor DPI scale, font atlas raster scale, 1x text sharpening). The UI is sized in DPI-independent units so it keeps the same physical size and layout on every monitor and platform; start here for any scaling/blurriness issue.
 - [.github/workflows/docs.yml](.github/workflows/docs.yml) — only CI workflow; publishes versioned docs.
 - [zensical.toml](zensical.toml) — docs site config (Material theme variant).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,7 @@ uv run zensical serve    # serve the docs locally at http://127.0.0.1:8000
 - **One logical change per PR.** Smaller PRs land faster and are easier to review.
 - **Update the docs** in [docs/](docs/) when you change user-visible behavior. The site is rebuilt automatically on push to `main`.
 - **Update [release.py](release.py)** if you add new runtime files (help texts, models, assets) — add them to the shared `datas`/`binaries` lists, a per-platform branch, or the `post_build()` copy step, otherwise they will be missing from the packaged release. The auto-generated `Autolume.spec` is gitignored; do not edit it.
+- **Put user preferences in [utils/user_data.py](utils/user_data.py)** if your change needs a persistent, user-facing setting (e.g. the data folder or UI font size). Add an accessor pair following the existing ones — preferences persist to a single JSON file (`~/.config/autolume/config.json`) — and expose the control in the Settings modal ([modules/settings.py](modules/settings.py)) rather than inventing a new config file.
 - **No automated test suite exists.** Verify your change manually by running `uv run main.py` and exercising the affected UI path. Describe what you tested in the PR.
 
 ## Commit message convention

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,3 +46,10 @@ The preferences file that records your data folder lives at
 
 Open **Settings** (the cog icon in the navbar) to point Autolume at a
 different folder, open it in your file manager, or reset it to the default.
+
+## Interface size
+
+The interface keeps the same physical size on every screen and never rescales
+when the window is resized or moved between monitors. To make it larger or
+smaller, open **Settings** and adjust the **UI font size** slider. The whole
+interface scales with it, and the value is remembered across launches.

--- a/modules/autolume_live.py
+++ b/modules/autolume_live.py
@@ -354,6 +354,10 @@ class Autolume(imgui_window.ImguiWindow):
             if clicked and not nav_disabled:
                 self.navigate_to(target_state)
 
+        # The icon buttons draw no text of their own. Pop back to the base font
+        # here so their tooltips render at the regular UI size.
+        imgui.pop_font()
+
         icon_size = round(nav_font * 0.9)
         button_width = icon_size + 2 * item_pad
         edge_pad = round(nav_font * 0.9)
@@ -373,7 +377,6 @@ class Autolume(imgui_window.ImguiWindow):
         if draw_icon_button(self.cog_texture, "Settings", icon_size, item_pad, self.navbar_height):
             self.open_settings()
 
-        imgui.pop_font()
         imgui.end()
 
     def _draw_module_fullscreen(self, title, module_callable):

--- a/modules/autolume_live.py
+++ b/modules/autolume_live.py
@@ -68,17 +68,23 @@ class Autolume(imgui_window.ImguiWindow):
     # Number of frames to hold the startup splash screen before opening the menu.
     SPLASH_FRAMES = 30
 
-    # Standard-DPI UI font size. Divided by the display's DPI scale so the UI is a
-    # constant, DPI-appropriate size that does NOT change when the window resizes.
-    # scale 1 (Windows/non-retina) -> 23 (clamps to the max key);
-    # scale 2 (retina)             -> 11.5 -> snaps to the min key 14.
-    BASE_FONT_SIZE = 23
+    # UI font size in DPI-independent units. _adjust_font_size multiplies it by
+    # the monitor's DPI scale so the UI keeps the same physical size on every
+    # display and platform, and never rescales with the window: 16px at 100%,
+    # 20 at 125%, 24 at 150%, 32 at 200% (macOS points are DPI-independent, so
+    # it stays 16pt there on every monitor and never reflows between screens).
+    UI_FONT_SIZE = 16
 
     # Navbar text, icons, and height are drawn this much larger than the base UI font.
     NAVBAR_SCALE = 1.25
 
     def __init__(self):
-        super().__init__(title='Autolume', window_width=3840, window_height=2160)
+        # Sizes cover the body font at common DPI scales (16/20/24/32 for
+        # 100/125/150/200%) and the matching navbar font (body * NAVBAR_SCALE:
+        # 20/25/30/40); the navbar draws from a font rasterized at its real
+        # size rather than scaling the base font.
+        super().__init__(title='Autolume', window_width=3840, window_height=2160,
+                         font_sizes=[*range(14, 26), 30, 32, 40])
 
         self.state = States.WELCOME
         self.running = True
@@ -117,7 +123,7 @@ class Autolume(imgui_window.ImguiWindow):
         self.comment_texture = gl_utils.Texture(image=self.comment, width=self.comment.shape[1],
                                                 height=self.comment.shape[0], channels=self.comment.shape[2])
 
-        self.navbar_height = round(self.BASE_FONT_SIZE * self.NAVBAR_SCALE * 2.2)
+        self.navbar_height = round(self.UI_FONT_SIZE * self.NAVBAR_SCALE * 2.2)
 
         # Initialize window.
         self.set_fps_limit(self.DEFAULT_FPS_LIMIT)
@@ -129,7 +135,7 @@ class Autolume(imgui_window.ImguiWindow):
 
     def _adjust_font_size(self):
         old = self.font_size
-        self.set_font_size(self.BASE_FONT_SIZE / self._font_dpi_scale)
+        self.set_font_size(self.scale_ui_size(self.UI_FONT_SIZE))
         if self.font_size != old:
             self.skip_frame() # Layout changed.
 
@@ -231,7 +237,8 @@ class Autolume(imgui_window.ImguiWindow):
 
     def draw_navbar(self):
         # Scale with the UI font, calibrated to 50px at font 23 before NAVBAR_SCALE.
-        nav_font = self.font_size * self.NAVBAR_SCALE
+        nav_font = round(self.font_size * self.NAVBAR_SCALE)
+        nav_font = min(self._imgui_fonts, key=lambda size: abs(size - nav_font))
         self.navbar_height = round(nav_font * 2.2)
         training_active = self._is_training_active()
 
@@ -245,8 +252,9 @@ class Autolume(imgui_window.ImguiWindow):
             imgui.WINDOW_NO_BRING_TO_FRONT_ON_FOCUS |
             imgui.WINDOW_NO_TITLE_BAR | imgui.WINDOW_NO_SCROLLBAR))
         imgui.pop_style_var(2)
-        # Enlarge text drawn in this window (and calc_text_size) to match the bar.
-        imgui.set_window_font_scale(self.NAVBAR_SCALE)
+        # Use a font rasterized at the navbar size; scaling the base font with
+        # set_window_font_scale stretches glyph quads and blurs on 1x displays.
+        imgui.push_font(self._imgui_fonts[nav_font])
 
         draw_list = imgui.get_window_draw_list()
         draw_list.add_rect_filled(
@@ -339,6 +347,7 @@ class Autolume(imgui_window.ImguiWindow):
         if draw_icon_button(self.cog_texture, "Settings", icon_size, item_pad, self.navbar_height):
             self.open_settings()
 
+        imgui.pop_font()
         imgui.end()
 
     def _draw_module_fullscreen(self, title, module_callable):

--- a/modules/autolume_live.py
+++ b/modules/autolume_live.py
@@ -8,6 +8,7 @@ import time
 import gc
 
 from assets import RED, OPAQUEGREEN, HOVERGREEN
+from utils import user_data
 from utils.gui_utils import imgui_window, gl_utils
 from utils.resource_paths import resource_path
 from widgets.help_icon_widget import DOCS_BASE_URL
@@ -70,21 +71,26 @@ class Autolume(imgui_window.ImguiWindow):
 
     # UI font size in DPI-independent units. _adjust_font_size multiplies it by
     # the monitor's DPI scale so the UI keeps the same physical size on every
-    # display and platform, and never rescales with the window: 16px at 100%,
-    # 20 at 125%, 24 at 150%, 32 at 200% (macOS points are DPI-independent, so
-    # it stays 16pt there on every monitor and never reflows between screens).
-    UI_FONT_SIZE = 16
+    # display and platform, and never rescales with the window (16px at 100%,
+    # 24 at 150%, 32 at 200%; macOS points are DPI-independent, so it stays
+    # constant there on every monitor and never reflows between screens).
+    # User-configurable in Settings, persisted via utils.user_data.
+    DEFAULT_UI_FONT_SIZE = 16
+    MIN_UI_FONT_SIZE = 12
+    MAX_UI_FONT_SIZE = 24
+
+    # Display scales the font atlas is pre-rasterized for (100/125/150/200%).
+    # Exotic scales snap to the nearest rasterized size.
+    DPI_SCALES = (1.0, 1.25, 1.5, 2.0)
 
     # Navbar text, icons, and height are drawn this much larger than the base UI font.
     NAVBAR_SCALE = 1.25
 
     def __init__(self):
-        # Sizes cover the body font at common DPI scales (16/20/24/32 for
-        # 100/125/150/200%) and the matching navbar font (body * NAVBAR_SCALE:
-        # 20/25/30/40); the navbar draws from a font rasterized at its real
-        # size rather than scaling the base font.
+        self.ui_font_size = self._clamp_ui_font_size(
+            user_data.ui_font_size(self.DEFAULT_UI_FONT_SIZE))
         super().__init__(title='Autolume', window_width=3840, window_height=2160,
-                         font_sizes=[*range(14, 26), 30, 32, 40])
+                         font_sizes=self._font_sizes_for(self.ui_font_size))
 
         self.state = States.WELCOME
         self.running = True
@@ -123,7 +129,7 @@ class Autolume(imgui_window.ImguiWindow):
         self.comment_texture = gl_utils.Texture(image=self.comment, width=self.comment.shape[1],
                                                 height=self.comment.shape[0], channels=self.comment.shape[2])
 
-        self.navbar_height = round(self.UI_FONT_SIZE * self.NAVBAR_SCALE * 2.2)
+        self.navbar_height = round(self.ui_font_size * self.NAVBAR_SCALE * 2.2)
 
         # Initialize window.
         self.set_fps_limit(self.DEFAULT_FPS_LIMIT)
@@ -133,9 +139,29 @@ class Autolume(imgui_window.ImguiWindow):
         self._adjust_font_size()
         self.skip_frame()  # Layout may change after first frame.
 
+    @classmethod
+    def _clamp_ui_font_size(cls, size):
+        return int(min(max(size, cls.MIN_UI_FONT_SIZE), cls.MAX_UI_FONT_SIZE))
+
+    @classmethod
+    def _font_sizes_for(cls, base):
+        # Rasterized sizes needed for this base: the body font at each supported
+        # DPI scale, plus the navbar font derived from each body size.
+        bodies = {round(base * scale) for scale in cls.DPI_SCALES}
+        navs = {round(body * cls.NAVBAR_SCALE) for body in bodies}
+        return sorted(bodies | navs)
+
+    def set_ui_font_size(self, size):
+        size = self._clamp_ui_font_size(size)
+        if size == self.ui_font_size:
+            return
+        self.ui_font_size = size
+        self.set_font_sizes(self._font_sizes_for(size))
+        user_data.set_ui_font_size(size)
+
     def _adjust_font_size(self):
         old = self.font_size
-        self.set_font_size(self.scale_ui_size(self.UI_FONT_SIZE))
+        self.set_font_size(self.scale_ui_size(self.ui_font_size))
         if self.font_size != old:
             self.skip_frame() # Layout changed.
 

--- a/modules/settings.py
+++ b/modules/settings.py
@@ -39,6 +39,7 @@ class Settings:
         self.browser = NativeBrowserWidget()
         # Edits stay in a working copy until the user applies them.
         self.pending_root = data_root()
+        self.pending_font_size = app.ui_font_size
         self.status = ""
         self._wants_open = False
         self._open = False
@@ -105,6 +106,27 @@ class Settings:
             if self.status:
                 imgui.spacing()
                 imgui.text_colored(self.status, 0.4, 0.8, 0.4)
+
+            imgui.spacing()
+            imgui.separator()
+            imgui.spacing()
+            imgui.text("UI font size")
+            imgui.text_colored(
+                "Base size of the interface text. The whole UI scales with it. "
+                "Applies on release and is remembered across launches.",
+                0.7, 0.7, 0.7)
+            _, self.pending_font_size = imgui.slider_int(
+                "##ui_font_size", self.pending_font_size,
+                self.app.MIN_UI_FONT_SIZE, self.app.MAX_UI_FONT_SIZE)
+            # Rebuilding the font atlas is too heavy per drag tick; apply once
+            # the slider is released (or after keyboard entry).
+            if not imgui.is_mouse_down(0) and self.pending_font_size != self.app.ui_font_size:
+                self.app.set_ui_font_size(self.pending_font_size)
+                self.pending_font_size = self.app.ui_font_size
+            imgui.same_line()
+            if imgui_utils.button("Default", width=self.app.font_size * 7):
+                self.app.set_ui_font_size(self.app.DEFAULT_UI_FONT_SIZE)
+                self.pending_font_size = self.app.ui_font_size
 
             imgui.spacing()
             imgui.separator()

--- a/utils/gui_utils/dpi.py
+++ b/utils/gui_utils/dpi.py
@@ -1,0 +1,101 @@
+"""Display-scale math for the imgui UI, in one place.
+
+Three coordinate spaces are involved; every function here converts between them:
+
+- **UI units**   — DPI-independent design units. The app expresses sizes it wants
+                   to look physically constant (e.g. the base font) in these.
+- **Logical units** — the space imgui lays out and draws in. Equal to GLFW window
+                   units on every platform *except* XWayland HiDPI, where GLFW
+                   reports window size in physical pixels and the renderer scales
+                   back to logical units itself.
+- **Physical pixels** — framebuffer pixels actually lit on the monitor.
+
+The two scale factors that relate them:
+
+- ``monitor_scale``  — physical pixels per UI unit (the OS "display scale":
+                       1.0 at 100%, 1.5 at 150%, 2.0 on retina / 200%).
+- ``pixels_per_logical`` — physical pixels per logical unit, i.e. the resolution
+                       the font atlas is rasterized at (2 on retina and XWayland
+                       HiDPI, 1 otherwise).
+
+All functions take the raw GLFW window handle and are pure queries.
+"""
+
+import sys
+
+import glfw
+import numpy as np
+
+# Contrast curve applied to the font atlas on 1x displays, where unhinted small
+# glyphs rasterize with soft coverage: cut the faint AA halo below the offset and
+# push stems toward solid. A stronger cousin of imgui's RasterizerMultiply, which
+# pyimgui 1.4.1 does not expose; values chosen by visual comparison on a 1x monitor.
+FONT_CONTRAST_OFFSET = 30
+FONT_CONTRAST_GAIN = 1.55
+
+
+def monitor_scale(window):
+    """OS display scale of the monitor the window is on: physical px per UI unit.
+
+    1.0 = 100%, 1.5 = 150%, 2.0 = retina / 200%. Per-window and updated by the OS
+    when the window moves to another monitor.
+    """
+    xscale, _ = glfw.get_window_content_scale(window)
+    return max(1.0, xscale)
+
+
+def window_unit_scale(window):
+    """GLFW window units per logical unit.
+
+    1.0 everywhere except XWayland HiDPI. macOS and native Wayland report logical
+    window units directly. Windows reports physical pixels but the app uses them
+    as its logical drawing space, so no correction there either. Only XWayland
+    reports physical pixels *and* expects logical layout, so its window size is
+    divided by the OS content scale.
+    """
+    if sys.platform != 'linux':
+        return 1.0
+    fb_w, _ = glfw.get_framebuffer_size(window)
+    win_w, _ = glfw.get_window_size(window)
+    if fb_w == win_w:
+        xscale, _ = glfw.get_window_content_scale(window)
+        return max(1.0, xscale)
+    return 1.0
+
+
+def pixels_per_logical(window):
+    """Physical pixels per logical unit — the font atlas rasterization scale.
+
+    2 on retina / XWayland HiDPI, 1 on standard-DPI monitors.
+    """
+    fb_w, _ = glfw.get_framebuffer_size(window)
+    logical_w = max(glfw.get_window_size(window)[0] / window_unit_scale(window), 1)
+    return max(1, round(fb_w / logical_w))
+
+
+def is_native_1x(window):
+    """True when 1 logical unit maps to exactly 1 physical pixel (a 100% monitor).
+
+    This is the gate for atlas sharpening: only there do the font's fractional
+    glyph advances land on fractional pixels and smear under bilinear sampling.
+    ``window`` may be None (renderer not yet bound to a window) -> False.
+    """
+    if window is None:
+        return False
+    return monitor_scale(window) <= 1.0 and pixels_per_logical(window) == 1
+
+
+def scale_ui_size(size, window):
+    """Convert a UI-unit size to logical units for the window's current monitor.
+
+    ``monitor_scale`` grows the size to the display's physical density;
+    ``pixels_per_logical`` divides back out where window units are already scaled
+    (retina points, XWayland-corrected logical units), leaving the UI physically
+    constant across monitors and platforms.
+    """
+    return round(size * monitor_scale(window) / pixels_per_logical(window))
+
+
+def sharpen_font_alpha(alpha):
+    """Apply the 1x contrast curve to a font-atlas alpha array (float or int)."""
+    return np.clip((alpha.astype(np.float32) - FONT_CONTRAST_OFFSET) * FONT_CONTRAST_GAIN, 0, 255)

--- a/utils/gui_utils/glfw_window.py
+++ b/utils/gui_utils/glfw_window.py
@@ -165,23 +165,21 @@ class GlfwWindow: # pylint: disable=too-many-public-methods
         self.set_window_size(width, height + self.title_bar_height)
 
     def maximize(self):
+        # Fill the work area explicitly rather than entering the OS "maximized"
+        # state: a maximized window snaps back to its smaller restored size the
+        # moment the user drags it (Windows), and maximize_window is also
+        # unreliable on XWayland and animates badly on undecorated macOS windows.
         area_x, area_y, area_width, area_height = self._get_work_area()
         tbh = round(self.title_bar_height * self._content_scale())  # logical → OS units
-        if sys.platform == 'darwin':
-            # maximize_window animates via NSWindow zoom and misbehaves on
-            # undecorated windows; set the frame directly instead.
-            glfw.set_window_pos(self._glfw_window, area_x, area_y + tbh)
-            glfw.set_window_size(self._glfw_window, area_width, max(area_height - tbh, 1))
-        elif _wayland_session():
-            # XWayland: maximize_window unreliable; fill work area explicitly.
+        if sys.platform != 'darwin':
+            # Clear any stale maximized state. Skipped on macOS, which never has
+            # one and where restoring a screen-filling window plays the NSWindow
+            # zoom animation.
             glfw.restore_window(self._glfw_window)
-            glfw.set_window_size(self._glfw_window, area_width, max(area_height - tbh, 1))
-        else:
-            # Clear stale maximized state and anchor at the work area origin
-            # (selects the right monitor) before maximizing.
-            glfw.restore_window(self._glfw_window)
+        if glfw.get_platform() != glfw.PLATFORM_WAYLAND:
+            # Wayland: compositor owns window position.
             glfw.set_window_pos(self._glfw_window, area_x, area_y + tbh)
-            glfw.maximize_window(self._glfw_window)
+        glfw.set_window_size(self._glfw_window, area_width, max(area_height - tbh, 1))
 
     def set_position(self, x, y):
         # Wayland: compositor owns window position.

--- a/utils/gui_utils/glfw_window.py
+++ b/utils/gui_utils/glfw_window.py
@@ -14,6 +14,7 @@ import glfw
 import OpenGL.GL as gl
 import PIL.Image
 from . import gl_utils
+from . import dpi
 from utils.resource_paths import resource_path
 
 
@@ -44,6 +45,13 @@ class GlfwWindow: # pylint: disable=too-many-public-methods
         # Create window.
         glfw.init()
         glfw.window_hint(glfw.VISIBLE, False)
+        # Windows measures windows in physical pixels and keeps their pixel size
+        # when dragged across monitors, while the UI font follows the monitor's
+        # DPI scale — the layout would reflow. Let GLFW resize the window by the
+        # DPI ratio on monitor change so the font-to-window ratio stays constant,
+        # matching the point-based (reflow-free) behavior macOS gives for free.
+        if sys.platform == 'win32':
+            glfw.window_hint(glfw.SCALE_TO_MONITOR, glfw.TRUE)
         # XWayland: force an EGL context so PyOpenGL's EGL platform (not the
         # buggy GLX one) picks it up.
         if _wayland_session():
@@ -87,16 +95,7 @@ class GlfwWindow: # pylint: disable=too-many-public-methods
             pass
 
     def _content_scale(self):
-        # macOS/native Wayland return logical pixels from get_window_size; no correction needed.
-        # XWayland returns physical pixels (fb == win), so read the OS content scale instead.
-        if sys.platform != 'linux':
-            return 1.0
-        fb_w, _ = glfw.get_framebuffer_size(self._glfw_window)
-        win_w, _ = glfw.get_window_size(self._glfw_window)
-        if fb_w == win_w:
-            xscale, _ = glfw.get_window_content_scale(self._glfw_window)
-            return max(1.0, xscale)
-        return 1.0
+        return dpi.window_unit_scale(self._glfw_window)
 
     @property
     def window_width(self):

--- a/utils/gui_utils/imgui_window.py
+++ b/utils/gui_utils/imgui_window.py
@@ -46,6 +46,7 @@ class ImguiWindow(glfw_window.GlfwWindow):
         imgui.get_io().mouse_drag_threshold = 0 # Improve behavior with imgui_utils.drag_custom().
         self._font_path  = font
         self._font_sizes = font_sizes
+        self._pending_font_sizes = None
         self._font_atlas_key = self._current_font_atlas_key()
         self._rebuild_font_atlas()
 
@@ -74,6 +75,22 @@ class ImguiWindow(glfw_window.GlfwWindow):
 
     def set_font_size(self, target): # Applied on next frame.
         self._cur_font_size = min((abs(key - target), key) for key in self._imgui_fonts.keys())[1]
+
+    def set_font_sizes(self, font_sizes): # Applied on next frame.
+        # Deferred like set_font_size: the atlas cannot be rebuilt mid-frame
+        # because the frame being drawn still references the old font objects.
+        self._pending_font_sizes = {int(size) for size in font_sizes}
+
+    def _apply_pending_font_sizes(self):
+        if self._pending_font_sizes is None:
+            return
+        sizes, self._pending_font_sizes = self._pending_font_sizes, None
+        if sizes == self._font_sizes:
+            return
+        self._font_sizes = sizes
+        self._rebuild_font_atlas()
+        self.set_font_size(self._cur_font_size) # Re-snap onto an existing size.
+        self.skip_frame()
 
     def scale_ui_size(self, size):
         # Convert a DPI-independent UI size to logical units for the current monitor.
@@ -117,6 +134,7 @@ class ImguiWindow(glfw_window.GlfwWindow):
         self._imgui_renderer.mouse_wheel_multiplier = self._cur_font_size / 10
         if self.content_width > 0 and self.content_height > 0:
             self._imgui_renderer.process_inputs()
+        self._apply_pending_font_sizes()
         self._update_font_scale()
 
         # Begin imgui frame.

--- a/utils/gui_utils/imgui_window.py
+++ b/utils/gui_utils/imgui_window.py
@@ -11,10 +11,13 @@ import sys
 import glfw
 import imgui
 import imgui.integrations.glfw
+import numpy as np
+import OpenGL.GL as gl
 
 from . import glfw_window
 from . import imgui_utils
 from . import text_utils
+from . import dpi
 
 #----------------------------------------------------------------------------
 
@@ -41,16 +44,10 @@ class ImguiWindow(glfw_window.GlfwWindow):
         self._attach_glfw_callbacks()
         imgui.get_io().ini_saving_rate = 0 # Disable creating imgui.ini at runtime.
         imgui.get_io().mouse_drag_threshold = 0 # Improve behavior with imgui_utils.drag_custom().
-        # Rasterize fonts at the framebuffer scale (2x on HiDPI) so text stays
-        # sharp; sizes exposed to the UI remain in logical (content) coordinates.
         self._font_path  = font
         self._font_sizes = font_sizes
-        fb_width = glfw.get_framebuffer_size(self._glfw_window)[0]
-        font_scale = max(1, round(fb_width / max(self.content_width, 1)))
-        self._font_dpi_scale = font_scale
-        imgui.get_io().font_global_scale = 1 / font_scale
-        self._imgui_fonts = {size: imgui.get_io().fonts.add_font_from_file_ttf(font, size * font_scale) for size in font_sizes}
-        self._imgui_renderer.refresh_font_texture()
+        self._font_atlas_key = self._current_font_atlas_key()
+        self._rebuild_font_atlas()
 
     def close(self):
         self.make_context_current()
@@ -78,18 +75,38 @@ class ImguiWindow(glfw_window.GlfwWindow):
     def set_font_size(self, target): # Applied on next frame.
         self._cur_font_size = min((abs(key - target), key) for key in self._imgui_fonts.keys())[1]
 
-    def _update_font_scale(self):
-        # Rebuild the font atlas when the window moves to a monitor with a different DPI scale.
-        fb_width = glfw.get_framebuffer_size(self._glfw_window)[0]
-        new_scale = max(1, round(fb_width / max(self.content_width, 1)))
-        if new_scale == self._font_dpi_scale:
-            return
-        self._font_dpi_scale = new_scale
-        imgui.get_io().font_global_scale = 1 / new_scale
-        imgui.get_io().fonts.clear()
-        self._imgui_fonts = {size: imgui.get_io().fonts.add_font_from_file_ttf(
-            self._font_path, size * new_scale) for size in self._font_sizes}
+    def scale_ui_size(self, size):
+        # Convert a DPI-independent UI size to logical units for the current monitor.
+        return dpi.scale_ui_size(size, self._glfw_window)
+
+    def _current_font_atlas_key(self):
+        # The atlas must be rebuilt whenever either of these changes: the raster
+        # scale (physical px per logical unit) or the 1x-sharpening state. On
+        # Windows the raster scale is always 1, so the 1x flag is the only signal
+        # that the window crossed onto a different-DPI monitor.
+        w = self._glfw_window
+        return (dpi.pixels_per_logical(w), dpi.is_native_1x(w))
+
+    def _rebuild_font_atlas(self):
+        # Rasterize each UI size at the monitor's physical resolution so text
+        # stays sharp; the sizes the app sees stay in logical units via
+        # font_global_scale.
+        raster_scale = self._font_atlas_key[0]
+        io = imgui.get_io()
+        io.font_global_scale = 1 / raster_scale
+        io.fonts.clear()
+        self._imgui_fonts = {size: io.fonts.add_font_from_file_ttf(
+            self._font_path, size * raster_scale) for size in self._font_sizes}
         self._imgui_renderer.refresh_font_texture()
+
+    def _update_font_scale(self):
+        # Rebuild the atlas when the window moves to a monitor that changes the
+        # atlas key (raster scale or 1x-sharpening state).
+        key = self._current_font_atlas_key()
+        if key == self._font_atlas_key:
+            return
+        self._font_atlas_key = key
+        self._rebuild_font_atlas()
         self.skip_frame()
 
     def begin_frame(self):
@@ -113,6 +130,44 @@ class ImguiWindow(glfw_window.GlfwWindow):
         imgui.end_frame()
         self._imgui_renderer.render(imgui.get_draw_data())
         super().end_frame()
+
+#----------------------------------------------------------------------------
+
+def _refresh_font_texture(renderer, alpha8):
+    # Upload the imgui font atlas, sharpened on 1x displays. There the font's
+    # fractional glyph advances put glyphs on fractional pixels, so bilinear
+    # sampling smears them: nearest-neighbor keeps glyphs bit-exact and the
+    # contrast curve restores stem solidity. On HiDPI the smear is
+    # sub-physical-pixel, so the stock bilinear path is kept. Shared by both
+    # backends; alpha8 for the fixed pipeline (macOS), rgba32 otherwise. The base
+    # renderer calls this once from __init__ before self.window is set (window is
+    # None -> not sharpened); ImguiWindow refreshes again after adding its fonts.
+    io = renderer.io
+    native_1x = dpi.is_native_1x(getattr(renderer, 'window', None))
+    last_texture = gl.glGetIntegerv(gl.GL_TEXTURE_BINDING_2D)
+    gl_format = gl.GL_ALPHA if alpha8 else gl.GL_RGBA
+    if alpha8:
+        width, height, pixels = io.fonts.get_tex_data_as_alpha8()
+        if native_1x:
+            pixels = dpi.sharpen_font_alpha(np.frombuffer(pixels, dtype=np.uint8)).astype(np.uint8).tobytes()
+    else:
+        width, height, pixels = io.fonts.get_tex_data_as_rgba32()
+        if native_1x:
+            rgba = np.frombuffer(pixels, dtype=np.uint8).reshape(-1, 4).copy()
+            rgba[:, 3] = dpi.sharpen_font_alpha(rgba[:, 3]).astype(np.uint8)
+            pixels = rgba.tobytes()
+    if renderer._font_texture is not None:
+        gl.glDeleteTextures([renderer._font_texture])
+    renderer._font_texture = gl.glGenTextures(1)
+    tex_filter = gl.GL_NEAREST if native_1x else gl.GL_LINEAR
+    gl.glBindTexture(gl.GL_TEXTURE_2D, renderer._font_texture)
+    gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MIN_FILTER, tex_filter)
+    gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MAG_FILTER, tex_filter)
+    gl.glTexImage2D(gl.GL_TEXTURE_2D, 0, gl_format, width, height, 0,
+                    gl_format, gl.GL_UNSIGNED_BYTE, pixels)
+    io.fonts.texture_id = renderer._font_texture
+    gl.glBindTexture(gl.GL_TEXTURE_2D, last_texture)
+    io.fonts.clear_tex_data()
 
 #----------------------------------------------------------------------------
 # Wrapper class for GlfwRenderer to fix a mouse wheel bug on Linux.
@@ -155,6 +210,9 @@ class _GlfwRenderer(imgui.integrations.glfw.GlfwRenderer):
     def scroll_callback(self, window, x_offset, y_offset):
         self.io.mouse_wheel += y_offset * self.mouse_wheel_multiplier
 
+    def refresh_font_texture(self):
+        _refresh_font_texture(self, alpha8=False)
+
 if sys.platform == 'darwin':
     # macOS offers either a GL 2.1 context or a 3.2+ core profile, never both.
     # The app draws with fixed-function GL, so it runs on the 2.1 context, where
@@ -163,9 +221,12 @@ if sys.platform == 'darwin':
     from imgui.integrations.opengl import FixedPipelineRenderer
 
     class _GlfwRenderer(_GlfwRenderer):
-        refresh_font_texture = FixedPipelineRenderer.refresh_font_texture
         render = FixedPipelineRenderer.render
         _create_device_objects = FixedPipelineRenderer._create_device_objects
         _invalidate_device_objects = FixedPipelineRenderer._invalidate_device_objects
+
+        def refresh_font_texture(self):
+            # The fixed pipeline needs the alpha8 atlas format.
+            _refresh_font_texture(self, alpha8=True)
 
 #----------------------------------------------------------------------------

--- a/utils/user_data.py
+++ b/utils/user_data.py
@@ -66,6 +66,21 @@ def save_prefs(prefs: dict) -> None:
         json.dump(prefs, fp, indent=2)
 
 
+def ui_font_size(default: int) -> int:
+    """Configured DPI-independent UI font size, or ``default`` if unset/invalid."""
+    try:
+        return int(load_prefs().get("ui_font_size", default))
+    except (TypeError, ValueError):
+        return default
+
+
+def set_ui_font_size(size: int) -> None:
+    """Persist the UI font size to the preferences file."""
+    prefs = load_prefs()
+    prefs["ui_font_size"] = int(size)
+    save_prefs(prefs)
+
+
 def data_root() -> str:
     """Configured writable data root (or the default)."""
     global _data_root


### PR DESCRIPTION
## Summary

The UI rescaled, reflowed, and blurred when the window moved between monitors of different DPI (retina vs external on macOS, HiDPI laptop vs standard monitor on Windows). The UI is now sized from a DPI-independent base multiplied by each monitor's OS scale, so it keeps the same physical size, proportions, and layout on every monitor across macOS, Windows, and Linux. The base size is user-configurable in Settings and persisted. Text on standard-DPI (1x) monitors is sharpened with nearest-neighbor atlas sampling and a contrast curve.

Details:
- All display-scale math lives in a new `utils/gui_utils/dpi.py`, with the three coordinate spaces (UI units, logical units, physical pixels) defined once.
- On Windows, `GLFW_SCALE_TO_MONITOR` rescales the window on DPI change so the layout never reflows, matching macOS's point-based behavior.
- The navbar draws from a font rasterized at its real size instead of scaling the base font, and its tooltips render at the base UI size.
- `maximize()` fills the work area explicitly instead of entering the OS maximized state, so dragging a maximized window on Windows no longer snaps it back to a small restored size.
- New user preference (`ui_font_size`) follows the existing `utils/user_data.py` pattern; AGENTS.md and CONTRIBUTING.md now document that module.

## Type of change

- [x] Feature
- [x] Fix
- [ ] Other (docs, refactor, chore, ci, etc.)

## How was this tested?

Manually on all three platforms (`uv run main.py`, Perform screen loaded with a 1024 model):
- macOS: dragged the window between the retina display and a 1x Dell U2719D. Same size and layout on both, text sharp on both, no reflow.
- Windows: dragged between a 150% laptop display and the same Dell at 100%. Window rescales on the monitor boundary, layout and physical size stay constant, text sharp on both.
- Ubuntu (Wayland): same checks, both screens correct and sharp.
- Settings: moved the UI font size slider across its range, confirmed the whole UI rescales on release and the value survives a restart.

Instrumented verification during development: framebuffer captures compared pixel-by-pixel across refactors (renders byte-identical before/after the consolidation into `dpi.py`), atlas sharpness measured numerically on the 1x monitor, and the DPI formula asserted on both macOS monitors.

## Checklist

- [x] PR title follows Conventional Commits without a scope (`<type>: <subject>`)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Documentation in `docs/` or `README.md` is updated if user-visible behavior changed
- [x] If this PR adds new runtime files, they are included in `release.py` (no new runtime files: `dpi.py` is ordinary bundled code)
- [ ] Screenshots or a short clip are attached for UI changes (before/after screenshots from the three-platform pass can be attached in a comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)