### PR TITLE
fix: prevent float32 truncation in float input widgets

### DIFF
--- a/modules/compress_module.py
+++ b/modules/compress_module.py
@@ -61,12 +61,12 @@ class CompressModule:
         picked = self.compress_dropdown(width=-1)
         if picked is not None:
             self.compress_pkl = picked
-        _, self.compression_factor = imgui.input_float("Compression Factor", self.compression_factor)
+        _, self.compression_factor = imgui_utils.input_float("Compression Factor", self.compression_factor)
         _, self.n_samples = imgui.input_int("Number of Samples", self.n_samples)
         _, self.batch_size_compress = imgui.input_int("Batch Size", self.batch_size_compress)
         if self.batch_size_compress < 1:
             self.batch_size_compress = 1
-        _, self.noise_prob = imgui.input_float("Noise Probability", self.noise_prob)
+        _, self.noise_prob = imgui_utils.input_float("Noise Probability", self.noise_prob)
 
         if imgui_utils.button('Compress', enabled=len(self.compress_pkl) > 0, width=-1):
             logger.info("Compressing model %s", self.compress_pkl)

--- a/modules/projection_module.py
+++ b/modules/projection_module.py
@@ -132,7 +132,7 @@ class ProjectionModule:
         imgui.text("Learning Rate")
         imgui.same_line()
         with imgui_utils.item_width(input_width):
-            _changed, self.lr = imgui.input_float("##lr", self.lr)
+            _changed, self.lr = imgui_utils.input_float("##lr", self.lr)
         
         imgui.text("Steps")
         imgui.same_line()

--- a/modules/training_module.py
+++ b/modules/training_module.py
@@ -307,10 +307,10 @@ class TrainingModule:
             if imgui.begin_popup_modal("Advanced...")[0]:
                 imgui.text("Advanced Training Options")
                 imgui.text("Generator Learning Rate")
-                _, self.glr = imgui.input_float("##Generator Learning Rate", self.glr)
+                _, self.glr = imgui_utils.input_float("##Generator Learning Rate", self.glr, format='%.6f')
 
                 imgui.text("Discriminator Learning Rate")
-                _, self.dlr = imgui.input_float("##Discriminator Learning Rate", self.dlr)
+                _, self.dlr = imgui_utils.input_float("##Discriminator Learning Rate", self.dlr, format='%.6f')
 
                 imgui.text("Gamma")
                 _, self.gamma = imgui.input_int("##Gamma", self.gamma)

--- a/utils/gui_utils/imgui_utils.py
+++ b/utils/gui_utils/imgui_utils.py
@@ -202,6 +202,24 @@ def input_text(label, value, buffer_length, flags, width=None, help_text=''):
 
 
 # ----------------------------------------------------------------------------
+# imgui passes float values through a C float every frame, so assigning the
+# returned value back unconditionally corrupts Python doubles even when the
+# user never touched the field. These wrappers keep the original value unless
+# the field actually changed, and round away float32 noise when it did.
+
+def input_float(label, value, *args, **kwargs):
+    changed, new_value = imgui.input_float(label, value, *args, **kwargs)
+    return changed, round(new_value, 6) if changed else value
+
+
+def input_float2(label, value0, value1, *args, **kwargs):
+    changed, values = imgui.input_float2(label, value0, value1, *args, **kwargs)
+    if changed:
+        return changed, tuple(round(v, 6) for v in values)
+    return changed, (value0, value1)
+
+
+# ----------------------------------------------------------------------------
 
 def drag_previous_control(enabled=True):
     dragging = False

--- a/widgets/collapsable_layer.py
+++ b/widgets/collapsable_layer.py
@@ -516,8 +516,8 @@ class LayerWidget:
                 if self.cur_layer is not None:
                     if "torgb" not in self.cur_layer and "output" not in self.cur_layer:
                         with imgui_utils.item_width(-1):
-                            _, ratio = imgui.input_float2(f"Ratio##{self.cur_layer}ratio", *ratio, format='%.2f',
-                                                          flags=imgui.INPUT_TEXT_ENTER_RETURNS_TRUE)
+                            _, ratio = imgui_utils.input_float2(f"Ratio##{self.cur_layer}ratio", *ratio, format='%.2f',
+                                                                flags=imgui.INPUT_TEXT_ENTER_RETURNS_TRUE)
 
                 if len(layers) > 0:
                     self.transform_widget(layers)
@@ -671,7 +671,7 @@ class LayerWidget:
                         with imgui_utils.item_width(self.viz.app.font_size * 8):
                             for j in range(len(trans.params)):
                                 if trans.type == "f":
-                                    changed, trans.params[j] = imgui.input_float(f"##{j}_{u_id}", trans.params[j])
+                                    changed, trans.params[j] = imgui_utils.input_float(f"##{j}_{u_id}", trans.params[j])
                                     imgui.same_line()
                                     _clicked, dragging, dx, dy = imgui_utils.drag_button(f"Drag##_{j}_{u_id}",
                                                                                          width=self.viz.app.button_w)
@@ -736,7 +736,7 @@ class LayerWidget:
         if modes[trans.mode] == "all":
             trans.indices = list(range(0, trans.max_idx))
         elif modes[trans.mode] == "random":
-            _changed, p = imgui.input_float("%##{trans.imgui_id}", trans.percentage)
+            _changed, p = imgui_utils.input_float("%##{trans.imgui_id}", trans.percentage)
             trans.percentage = np.clip(p, 0, 1)
             imgui.same_line()
             if imgui_utils.button(f"randomize##{trans.imgui_id}", width=self.viz.app.button_w) or _changed or update:

--- a/widgets/layer_widget.py
+++ b/widgets/layer_widget.py
@@ -224,8 +224,8 @@ class LayerWidget:
                 if self.cur_layer is not None:
                     if "torgb" not in self.cur_layer and "output" not in self.cur_layer:
                         with imgui_utils.item_width(-1):
-                            _, ratio = imgui.input_float2(f"Ratio##{self.cur_layer}ratio", *ratio, format='%.2f',
-                                                          flags=imgui.INPUT_TEXT_ENTER_RETURNS_TRUE)
+                            _, ratio = imgui_utils.input_float2(f"Ratio##{self.cur_layer}ratio", *ratio, format='%.2f',
+                                                                flags=imgui.INPUT_TEXT_ENTER_RETURNS_TRUE)
 
                 # if imgui_utils.button(f"{label}##adjust", width=-1):
                 #     self.mode = not self.mode
@@ -353,7 +353,7 @@ class LayerWidget:
                         with imgui_utils.item_width(self.viz.app.font_size * 8):
                             for j in range(len(trans.params)):
                                 if trans.type == "f":
-                                    changed, trans.params[j] = imgui.input_float(f"##{j}_{u_id}", trans.params[j])
+                                    changed, trans.params[j] = imgui_utils.input_float(f"##{j}_{u_id}", trans.params[j])
                                     imgui.same_line()
                                     _clicked, dragging, dx, dy = imgui_utils.drag_button(f"Drag##_{j}_{u_id}",
                                                                                          width=self.viz.app.button_w)
@@ -427,7 +427,7 @@ class LayerWidget:
         if modes[trans.mode] == "all":
             trans.indices = list(range(0, trans.max_idx))
         elif modes[trans.mode] == "random":
-            _changed, p = imgui.input_float("%##{trans.imgui_id}", trans.percentage)
+            _changed, p = imgui_utils.input_float("%##{trans.imgui_id}", trans.percentage)
             trans.percentage = np.clip(p, 0, 1)
             imgui.same_line()
             if imgui_utils.button(f"randomize##{trans.imgui_id}", width=self.viz.app.button_w) or _changed or update:

--- a/widgets/looping_widget.py
+++ b/widgets/looping_widget.py
@@ -496,7 +496,7 @@ class LoopingWidget:
 
                 imgui.same_line()
                 with imgui_utils.item_width(viz.app.font_size * 5):
-                    radius_changed, self.radius = imgui.input_float("Radius", self.radius)
+                    radius_changed, self.radius = imgui_utils.input_float("Radius", self.radius)
                 if seed_changed or radius_changed:
                     self.args_queue.put((self.noise_seed, self.radius))
 


### PR DESCRIPTION
## Summary

Merely opening a panel with an `imgui.input_float` widget corrupted the backing value: pyimgui passes the value through a C float every frame and the code assigned the truncated result back unconditionally, so e.g. a learning rate of `0.002` became `0.0020000000949949026` in the training kwargs and `training_options.json`. New `imgui_utils.input_float`/`input_float2` wrappers keep the original Python value unless the field actually changed and round away float32 noise when it did; all affected call sites now use them.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Other (docs, refactor, chore, ci, etc.)

## How was this tested?

- Reproduced the bug in a headless imgui harness: three rendered frames with no user interaction turned `0.002` into `float32(0.002)` under the old pattern, while the wrappers keep `0.002`, `0.15`, and `(1, 1)` exact across frames.
- Confirmed the dirty value in a real run's `training_options.json` is bit-for-bit `float32(0.002)`, matching the root cause.
- Manually tested in the app: edited learning rates, layer ratio, and transform params; entry behaves normally.

Affected call sites: training module learning rates (also now displayed with `%.6f` instead of the misleading `%.3f` default), compress module compression factor and noise probability, projection module learning rate, looping widget radius, and the layer ratio, transform params, and random-mode percentage in both `layer_widget.py` and `collapsable_layer.py` (the ratio was silently truncated into `self.ratios` every frame). The seed-fraction inputs in `looping_widget.py` and `latent_widget.py` were left alone since they already gate on the changed flag and recompute per frame.

## Checklist

- [x] PR title follows Conventional Commits without a scope (`<type>: <subject>`)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] Documentation in `docs/` or `README.md` is updated if user-visible behavior changed
- [x] If this PR adds new runtime files, they are included in `release.py` (no new runtime files)
- [ ] Screenshots or a short clip are attached for UI changes