### PR TITLE
fix: submit render args on every change to restore smooth pacing

### DIFF
--- a/modules/renderloop.py
+++ b/modules/renderloop.py
@@ -58,10 +58,12 @@ class AsyncRenderer:
 
     def set_args(self, **args):
         if not self._closed:
-            if self._args_queue.empty():
-                if not compare_args(args, self._cur_args):
-                    self._args_queue.put([args, self._cur_stamp])
-                self._cur_args = args
+            # Put every change. The render loop drains the queue and renders
+            # the latest args, so pacing follows render speed and stale args
+            # are skipped.
+            if not compare_args(args, self._cur_args):
+                self._args_queue.put([args, self._cur_stamp])
+            self._cur_args = args
 
     def get_result(self):
         if not self._closed:


### PR DESCRIPTION
## Summary

Fixes a regression on macOS introduced by d36276b: motion became bursty at steady FPS — the animation lurches ahead, then crawls, then lurches. Root cause is a race between the `set_args` gate on `args_queue.empty()` and the render process's blocking `get()`: an idle renderer consumes a put the instant it lands, reopening the gate one GUI frame early, so the GUI double-submits near-identical latent steps and the drain loop then skips ahead to catch up. This PR removes the emptiness gate: args are put on every change and the render loop's existing drain-to-latest picks the freshest one, so pacing is clocked by render speed instead of the race. The race is platform-independent, but at MPS frame rates a render spans several GUI frames, which makes the uneven steps clearly visible on macOS.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Other (docs, refactor, chore, ci, etc.)

## How was this tested?

Headless harness driving the real `AsyncRenderer` (subprocess + queues) with seed-walk args at 60 Hz on MPS (M-series, rivers-1024 model), measuring the latent step ("content stride") each rendered frame actually advanced:

- Before (d36276b, 3 runs): stride alternates 1 / 7 / 12–13 ticks, cv ≈ 0.55–0.62 — visible lurch/crawl.
- Parent of d36276b (3 runs): uniform stride 6–9, cv ≈ 0.09–0.11.
- With this fix on top of d36276b (2 runs): uniform stride 6–9, cv ≈ 0.06–0.08, identical fps (8.6) and frame-time cv (0.03–0.05).

Rendered args are also fresher: about one GUI frame stale instead of a full render period. Frame *times* never regressed on any commit; only content pacing did, which is why FPS counters look fine.

Manual testing in the app on both macOS (MPS) and Windows (CUDA): loaded a model, dragged sliders, and ran latent animation — motion is smooth on both platforms, with no regressions observed around preset load or model switching.

## Checklist

- [x] PR title follows Conventional Commits without a scope (`<type>: <subject>`)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Documentation in `docs/` or `README.md` is updated if user-visible behavior changed (no user-visible behavior change other than the fix)
- [x] If this PR adds new runtime files, they are included in `release.py` (no new runtime files)
- [ ] Screenshots or a short clip are attached for UI changes (not a UI change)