### PR TITLE
Ship precompiled custom CUDA ops and reduce the bundle size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ dist/
 build/
 *.spec
 
+# Custom ops build cache
+torch_extensions/
+
 # MkDocs
 site/
 

--- a/main.py
+++ b/main.py
@@ -43,6 +43,14 @@ def get_runtime_bin_dir():
 BIN_DIR = get_runtime_bin_dir()
 os.environ["PATH"] = BIN_DIR + os.pathsep + os.environ.get("PATH", "")
 
+if IS_FROZEN:
+    # imageio-ffmpeg's own binary is pruned from the bundle (release.py);
+    # route it to the ffmpeg already shipped in bin/.
+    os.environ.setdefault(
+        "IMAGEIO_FFMPEG_EXE",
+        os.path.join(BIN_DIR, "ffmpeg.exe" if os.name == "nt" else "ffmpeg"),
+    )
+
 
 def main():
     # Materialise the user data root so it is discoverable even before any

--- a/main.py
+++ b/main.py
@@ -4,6 +4,15 @@ import sys
 
 IS_FROZEN = getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")
 
+# Build cache for the custom CUDA ops: precompiled entries ship inside the
+# bundle; in development the cache lives at the repository root. Must be set
+# before the first op is loaded and is inherited by spawned worker processes.
+os.environ.setdefault(
+    "TORCH_EXTENSIONS_DIR",
+    os.path.join(sys._MEIPASS, "torch_extensions") if IS_FROZEN
+    else os.path.join(os.path.dirname(os.path.abspath(__file__)), "torch_extensions"),
+)
+
 if sys.platform == 'darwin':
     # Must be set before torch is imported.
     os.environ.setdefault('PYTORCH_ENABLE_MPS_FALLBACK', '1')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "ninja==1.11.1.1",
     "numpy==1.26.4",
     "openai-clip==1.0.1",
-    "opencv-python==4.8.1.78",
+    "opencv-python-headless==4.8.1.78",
     "opensimplex==0.4.5",
     "pillow==10.4.0",
     "psutil>=6.0.0",

--- a/release.py
+++ b/release.py
@@ -15,7 +15,7 @@ right PyInstaller invocation:
   produces an ``Autolume.app`` bundle instead of a plain folder.
 
 ffmpeg/ffprobe are bundled on every platform via ffmpeg-downloader so the
-artifact is self-contained.
+artifact is self-contained (Windows uses gyan.dev's essentials build).
 
 PyInstaller cannot cross-compile: each artifact must be built on its own OS.
 """
@@ -73,12 +73,30 @@ def spec_arg(src: Path, dest: str) -> str:
     return f"{src}{os.pathsep}{dest}"
 
 
+# Windows bundles gyan.dev's "essentials" ffmpeg (~97 MB/exe vs ~136 MB for
+# the default full build); libx264 + aac is all Autolume uses. The major
+# version is pinned because "release@essentials" resolves the latest version
+# across all providers, usually a btbn post-release with no essentials build.
+FFMPEG_WIN_SPEC = "8@essentials"
+
+
 def ensure_ffmpeg() -> tuple[Path, Path]:
     """Make sure ffmpeg + ffprobe are downloaded and return their paths."""
+    if IS_WINDOWS and ffdl.installed():
+        banner = subprocess.run(
+            [ffdl.ffmpeg_path, "-version"], capture_output=True, text=True
+        ).stdout.partition("\n")[0]
+        if "essentials_build" not in banner:
+            print(f"Cached ffmpeg is not the essentials build ({banner}); replacing...")
+            subprocess.run(
+                [sys.executable, "-m", "ffmpeg_downloader", "uninstall", "-y"], check=True
+            )
     if not ffdl.installed():
         print("Installing ffmpeg via ffmpeg-downloader...")
         cmd = [sys.executable, "-m", "ffmpeg_downloader", "install", "-y"]
-        if not IS_WINDOWS:
+        if IS_WINDOWS:
+            cmd.append(FFMPEG_WIN_SPEC)
+        else:
             cmd.append("--no-simlinks")  # don't touch the user's ~/.local/bin
         subprocess.run(cmd, check=True)
     ffmpeg = ffdl.ffmpeg_path and Path(ffdl.ffmpeg_path)
@@ -174,9 +192,20 @@ def build_args() -> list[str]:
         binaries.append((ninja_binary(), "bin"))  # same collision risk as ffmpeg
 
         torch_lib = package_dir("torch") / "lib"
-        link_libs = "*.lib" if IS_WINDOWS else "*.so*"
-        for lib in sorted(torch_lib.glob(link_libs)):
-            binaries.append((lib, "torch/lib"))
+        if IS_WINDOWS:
+            # Only the import libraries that torch.utils.cpp_extension links
+            # (see _prepare_ldflags there). The other *.lib in torch/lib are
+            # static libraries the JIT never uses; dnnl.lib alone is 2.2 GB.
+            jit_link_libs = ["c10.lib", "c10_cuda.lib", "torch.lib",
+                             "torch_cpu.lib", "torch_cuda.lib", "torch_python.lib"]
+            for name in jit_link_libs:
+                lib = torch_lib / name
+                if not lib.exists():
+                    fail(f"expected torch import library not found: {lib}")
+                binaries.append((lib, "torch/lib"))
+        else:
+            for lib in sorted(torch_lib.glob("*.so*")):
+                binaries.append((lib, "torch/lib"))
 
         datas.append((package_dir("torch") / "include", "torch/include"))
 
@@ -233,6 +262,43 @@ def clean() -> None:
             shutil.rmtree(target)
 
 
+# Collected binaries the app can never reach, deleted from the bundle after
+# PyInstaller runs (globs relative to dist/Autolume).
+PRUNE_PATTERNS = [
+    # PyInstaller copies nvrtc to the bundle root as an import of
+    # caffe2_nvrtc.dll, but the loader resolves the torch/lib copy via torch's
+    # add_dll_directory; the root copy is an 83 MB dead duplicate.
+    "_internal/nvrtc64_*.dll",
+    # Multi-GPU cusolver backend (150 MB); torch_cuda.dll does not import it
+    # and nothing in Autolume reaches the cusolverMg APIs.
+    "_internal/torch/lib/cusolverMg64_*.dll",
+    # imageio-ffmpeg's own ffmpeg (62 MB); main.py points IMAGEIO_FFMPEG_EXE
+    # at the ffmpeg already shipped in bin/.
+    "_internal/imageio_ffmpeg/binaries/ffmpeg-*",
+    # cuRAND (69 MB); nothing in the bundle references it, torch uses its own
+    # Philox RNG on CUDA. Verified by training + inference with it removed.
+    "_internal/torch/lib/curand64_*.dll",
+    # cuDNN's RNN/attention sub-library (269 MB), loaded lazily by the cudnn
+    # shim; StyleGAN is conv-only. Verified by training + inference with it
+    # removed.
+    "_internal/torch/lib/cudnn_adv64_*.dll",
+    # Alternate nvrtc build (83 MB); nothing references it and the primary
+    # nvrtc ships alongside.
+    "_internal/torch/lib/nvrtc64_*.alt.dll",
+]
+
+
+def prune_bundle() -> None:
+    bundle = REPO / "dist" / "Autolume"
+    freed = 0
+    for pattern in PRUNE_PATTERNS:
+        for path in bundle.glob(pattern):
+            freed += path.stat().st_size
+            path.unlink()
+            print(f"Pruned {path.relative_to(bundle)}")
+    print(f"Pruning freed {freed / 1024 / 1024:.0f} MB")
+
+
 def post_build() -> None:
     # Read-only resources are bundled and resolved via utils.resource_paths, so
     # nothing needs to be copied next to the executable. Writable user-output
@@ -253,6 +319,7 @@ def post_build() -> None:
         subprocess.run(["codesign", "--force", "--sign", "-", str(app)], check=True)
         print(f"Built dist/Autolume.app (requires macOS {MACOS_MIN_VERSION}+)")
     else:
+        prune_bundle()
         print(f"Release created in {REPO / 'dist' / 'Autolume'}")
 
 

--- a/release.py
+++ b/release.py
@@ -3,12 +3,16 @@
 Run with ``uv run release.py``. Detects the host platform and assembles the
 right PyInstaller invocation:
 
-- Windows / Linux bundle the runtime JIT toolchain (torch headers + libs, ninja,
-  python headers) because the custom StyleGAN ops are compiled on first use when
-  running on CUDA. Windows additionally ships the Python import library
-  (e.g. ``python312.lib``).
-- macOS skips that toolchain entirely (the ops fall back to reference PyTorch on
-  MPS) and produces an ``Autolume.app`` bundle instead of a plain folder.
+- Windows / Linux precompile the custom StyleGAN CUDA ops for compute
+  capabilities 7.5/8.6/8.9/12.0 (RTX 20/30/40/50 series) via
+  ``scripts/precompile_ops.py`` and ship them in the bundle, so users need no
+  compiler or CUDA toolkit. They also bundle the runtime JIT toolchain (torch
+  headers + libs, ninja, python headers) so cards with other compute
+  capabilities can fall back to compiling the ops on first use (this requires
+  MSVC/GCC + CUDA nvcc on the user's machine). Windows additionally ships the
+  Python import library (e.g. ``python312.lib``).
+- macOS skips all of that (the ops fall back to reference PyTorch on MPS) and
+  produces an ``Autolume.app`` bundle instead of a plain folder.
 
 ffmpeg/ffprobe are bundled on every platform via ffmpeg-downloader so the
 artifact is self-contained.
@@ -36,8 +40,12 @@ IS_WINDOWS = SYSTEM == "Windows"
 IS_MACOS = SYSTEM == "Darwin"
 IS_LINUX = SYSTEM == "Linux"
 
-# Windows and Linux compile the custom CUDA ops at runtime; macOS does not.
+# Windows and Linux ship precompiled custom CUDA ops with a runtime JIT
+# fallback for other compute capabilities; macOS uses neither.
 NEEDS_JIT_TOOLCHAIN = IS_WINDOWS or IS_LINUX
+
+# Staging dir for the precompiled ops bundled into the release.
+PRECOMPILED_OPS_DIR = REPO / "build" / "torch_extensions"
 
 # torch 2.8 wheels ship a libomp.dylib stamped minos 14.0 despite the
 # macosx_11_0_arm64 tag (pytorch/pytorch#177140), so the bundle cannot load on
@@ -159,8 +167,10 @@ def build_args() -> list[str]:
         (clip / "bpe_simple_vocab_16e6.txt.gz", "clip"),
     ]
 
-    # --- Runtime JIT toolchain (Windows + Linux only) ---------------------
+    # --- Precompiled CUDA ops + runtime JIT toolchain (Windows + Linux) ---
     if NEEDS_JIT_TOOLCHAIN:
+        datas.append((PRECOMPILED_OPS_DIR, "torch_extensions"))
+
         binaries.append((ninja_binary(), "bin"))  # same collision risk as ffmpeg
 
         torch_lib = package_dir("torch") / "lib"
@@ -205,6 +215,16 @@ def build_args() -> list[str]:
     return args
 
 
+def precompile_ops() -> None:
+    """Build the custom CUDA ops for the supported archs and stage them for bundling."""
+    print("Precompiling custom CUDA ops...")
+    subprocess.run(
+        [sys.executable, str(REPO / "scripts" / "precompile_ops.py"), "--export", str(PRECOMPILED_OPS_DIR)],
+        check=True,
+        cwd=REPO,
+    )
+
+
 def clean() -> None:
     for name in ("dist", "build"):
         target = REPO / name
@@ -239,6 +259,8 @@ def post_build() -> None:
 def main() -> None:
     print(f"Building Autolume for {SYSTEM}...")
     clean()
+    if NEEDS_JIT_TOOLCHAIN:
+        precompile_ops()
     args = build_args()
     print("Running PyInstaller...")
     subprocess.run(args, check=True, cwd=REPO)

--- a/scripts/precompile_ops.py
+++ b/scripts/precompile_ops.py
@@ -1,0 +1,148 @@
+"""Precompile the custom C++/CUDA ops into the shared build cache.
+
+Warms exactly the cache that torch_utils.ops.custom_ops loads from: after
+precompiling on a machine with a full CUDA/MSVC toolchain, any environment
+sharing the cache (same torch, CUDA and Python versions) loads the ops
+without compiler access. Drives torch.utils.cpp_extension's ninja build
+directly instead of custom_ops.get_plugin so that a single process can
+build for many compute capabilities without importing the built modules.
+
+Each plugin is built once as a single fatbin entry covering all requested
+compute capabilities.
+
+The cache lives at <repo>/torch_extensions, where the app loads it from in
+development mode; set TORCH_EXTENSIONS_DIR to relocate it. --export copies
+the entries stripped down to the loadable artifacts, ready to ship in the
+release bundle.
+
+Examples:
+
+\b
+# Precompile for the release archs (RTX 20/30/40/50 series).
+python scripts/precompile_ops.py
+
+\b
+# Precompile for explicit compute capabilities.
+python scripts/precompile_ops.py --arch=8.6,8.9
+"""
+
+import os
+import shutil
+import sys
+
+_REPO_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _REPO_DIR)
+os.environ.setdefault('TORCH_EXTENSIONS_DIR', os.path.join(_REPO_DIR, 'torch_extensions'))
+
+import click
+import torch
+import torch.utils.cpp_extension
+
+from torch_utils import build_cache
+
+DEFAULT_ARCHS = '7.5,8.6,8.9,12.0'
+
+#----------------------------------------------------------------------------
+# Keep in sync with the _init() calls in
+# torch_utils/ops/{bias_act,filtered_lrelu,upfirdn2d}.py.
+
+_OPS_DIR = os.path.join(_REPO_DIR, 'torch_utils', 'ops')
+
+PLUGIN_SPECS = [
+    dict(module_name='bias_act_plugin',
+         sources=['bias_act.cpp', 'bias_act.cu'],
+         headers=['bias_act.h'],
+         extra_cuda_cflags=['--use_fast_math', '--allow-unsupported-compiler']),
+    dict(module_name='filtered_lrelu_plugin',
+         sources=['filtered_lrelu.cpp', 'filtered_lrelu_wr.cu', 'filtered_lrelu_rd.cu', 'filtered_lrelu_ns.cu'],
+         headers=['filtered_lrelu.h', 'filtered_lrelu.cu'],
+         extra_cuda_cflags=['--use_fast_math', '--allow-unsupported-compiler']),
+    dict(module_name='upfirdn2d_plugin',
+         sources=['upfirdn2d.cpp', 'upfirdn2d.cu'],
+         headers=['upfirdn2d.h'],
+         extra_cuda_cflags=['--use_fast_math', '--allow-unsupported-compiler']),
+]
+
+#----------------------------------------------------------------------------
+
+def build_plugin(spec, capabilities, verbose):
+    module_name = spec['module_name']
+    sources = [os.path.join(_OPS_DIR, fname) for fname in spec['sources']]
+    headers = [os.path.join(_OPS_DIR, fname) for fname in spec['headers']]
+    all_source_files = sorted(sources + headers)
+
+    build_dir = build_cache.plugin_build_dir(module_name, all_source_files, capabilities, verbose=verbose)
+    if build_cache.is_complete(build_dir, module_name):
+        return 'cached', build_dir
+
+    build_cache.clean_failed_build(build_dir, module_name)
+    build_cache.populate_sources(build_dir, all_source_files)
+    build_cache.pin_arch_list(';'.join(capabilities))
+    cached_sources = [os.path.join(build_dir, os.path.basename(fname)) for fname in sources]
+    torch.utils.cpp_extension._write_ninja_file_and_build_library( # pylint: disable=protected-access
+        name=module_name,
+        sources=cached_sources,
+        extra_cflags=[],
+        extra_cuda_cflags=spec['extra_cuda_cflags'],
+        extra_sycl_cflags=[],
+        extra_ldflags=[],
+        extra_include_paths=[],
+        build_directory=build_dir,
+        verbose=verbose,
+        with_cuda=True,
+        with_sycl=False)
+    build_cache.mark_complete(build_dir, module_name)
+    return 'built', build_dir
+
+#----------------------------------------------------------------------------
+
+def export_entry(build_dir, module_name, export_dir):
+    """Copy a complete cache entry keeping only what import_from_cache needs:
+    the compiled artifact and the completion marker."""
+    entry_dir = os.path.join(export_dir, module_name, os.path.basename(build_dir))
+    os.makedirs(entry_dir, exist_ok=True)
+    artifact = build_cache._artifact_path(build_dir, module_name) # pylint: disable=protected-access
+    shutil.copyfile(artifact, os.path.join(entry_dir, os.path.basename(artifact)))
+    marker = os.path.join(build_dir, build_cache._COMPLETE_MARKER) # pylint: disable=protected-access
+    shutil.copyfile(marker, os.path.join(entry_dir, os.path.basename(marker)))
+
+#----------------------------------------------------------------------------
+
+@click.command(help=__doc__)
+@click.option('--arch', 'archs', default=DEFAULT_ARCHS, show_default=True,
+              help='Comma-separated compute capabilities to build for.')
+@click.option('--export', 'export_dir', type=click.Path(file_okay=False),
+              help='Also copy the built entries (artifact + completion marker only) into this directory.')
+@click.option('--allow-toolkit-mismatch', is_flag=True,
+              help='Build even if the CUDA toolkit major version differs from the torch CUDA runtime.')
+@click.option('--verbose', is_flag=True, help='Show build output.')
+def main(archs, export_dir, allow_toolkit_mismatch, verbose):
+    if torch.version.cuda is None:
+        raise click.ClickException('CUDA-enabled torch build required.')
+    archs = [arch.strip() for arch in archs.replace(';', ',').split(',') if arch.strip()] or [build_cache.current_capability()]
+    build_cache.setup_compiler_env()
+    mismatch = build_cache.toolkit_mismatch()
+    if mismatch is not None:
+        toolkit, runtime = mismatch
+        if not allow_toolkit_mismatch:
+            raise click.ClickException(
+                f'CUDA toolkit {toolkit} does not match the torch CUDA runtime {runtime}. Ops precompiled this '
+                f'way embed the CUDA {toolkit.split(".")[0]} runtime and need a correspondingly recent GPU driver '
+                f'on every machine that loads this cache. Set CUDA_HOME/CUDA_PATH to a CUDA '
+                f'{runtime.split(".")[0]}.x toolkit, or pass --allow-toolkit-mismatch to build anyway.')
+        build_cache.warn_toolkit_mismatch()
+    for spec in PLUGIN_SPECS:
+        print(f'Building {spec["module_name"]} for sm{"_".join(sorted(archs, key=float))}... ', end='', flush=True)
+        status, build_dir = build_plugin(spec, archs, verbose)
+        print(status)
+        if export_dir:
+            export_entry(build_dir, spec['module_name'], export_dir)
+    if export_dir:
+        print(f'Exported entries to {export_dir}')
+
+#----------------------------------------------------------------------------
+
+if __name__ == '__main__':
+    main() # pylint: disable=no-value-for-parameter
+
+#----------------------------------------------------------------------------

--- a/torch_utils/build_cache.py
+++ b/torch_utils/build_cache.py
@@ -1,0 +1,209 @@
+"""Shared build-cache utilities for the custom C++/CUDA ops.
+
+Both the JIT loader (`torch_utils.custom_ops`) and the standalone
+precompiler (`scripts/precompile_ops.py`) build into the same on-disk cache.
+A cache entry is keyed by (source digest, Python version, torch version,
+compute capabilities) -- never by GPU name -- so entries are shared across
+GPUs of the same compute capability and can be produced on one machine and
+consumed on another. A single entry may cover several compute capabilities (a fatbin
+built by the precompiler); the loader picks any complete entry whose arch
+set contains the current device. An entry is only trusted once its
+completion marker exists; incomplete entries are treated as failed builds
+and deleted before rebuilding. A complete entry is imported directly from
+disk, without compiler or CUDA toolkit access.
+"""
+
+import glob
+import hashlib
+import importlib.machinery
+import importlib.util
+import os
+import re
+import shutil
+import subprocess
+import sys
+import uuid
+
+import torch
+import torch.utils.cpp_extension
+
+_COMPLETE_MARKER = '.build_complete'
+
+#----------------------------------------------------------------------------
+# Cache key and directory resolution.
+
+def source_digest(source_files):
+    hash_md5 = hashlib.md5()
+    for src in sorted(source_files):
+        with open(src, 'rb') as f:
+            hash_md5.update(f.read())
+    return hash_md5.hexdigest()
+
+def current_capability():
+    major, minor = torch.cuda.get_device_capability()
+    return f'{major}.{minor}'
+
+def _arch_tag(capabilities):
+    return 'sm' + '_'.join(sorted(capabilities, key=float))
+
+def _key_prefix(source_files):
+    # The Python tag duplicates torch's default py/cu-versioned cache layout,
+    # but keeps entries self-contained when TORCH_EXTENSIONS_DIR relocates
+    # the cache to a flat directory.
+    return f'{source_digest(source_files)}-py{sys.version_info.major}{sys.version_info.minor}-torch{torch.__version__}-'
+
+def plugin_build_dir(module_name, source_files, capabilities, verbose=False):
+    assert torch.version.cuda is not None, 'CUDA-enabled torch build required'
+    root = torch.utils.cpp_extension._get_build_directory(module_name, verbose=verbose) # pylint: disable=protected-access
+    return os.path.join(root, _key_prefix(source_files) + _arch_tag(capabilities))
+
+def find_compatible_build_dir(module_name, source_files, capability, verbose=False):
+    """Complete cache entry usable on a device of the given capability:
+    the exact single-arch entry if complete, else any complete entry whose
+    arch set contains the capability, else None."""
+    exact = plugin_build_dir(module_name, source_files, [capability], verbose=verbose)
+    if is_complete(exact, module_name):
+        return exact
+    pattern = os.path.join(os.path.dirname(exact), _key_prefix(source_files) + 'sm*')
+    for build_dir in sorted(glob.glob(pattern)):
+        archs = os.path.basename(build_dir).rsplit('-sm', 1)[1].split('_')
+        if capability in archs and is_complete(build_dir, module_name):
+            return build_dir
+    return None
+
+#----------------------------------------------------------------------------
+# Entry completion state and failed-build cleanup.
+
+def _artifact_path(build_dir, module_name):
+    ext = '.pyd' if os.name == 'nt' else '.so'
+    return os.path.join(build_dir, module_name + ext)
+
+def is_complete(build_dir, module_name):
+    return os.path.isfile(os.path.join(build_dir, _COMPLETE_MARKER)) and os.path.isfile(_artifact_path(build_dir, module_name))
+
+def mark_complete(build_dir, module_name):
+    artifact = _artifact_path(build_dir, module_name)
+    assert os.path.isfile(artifact), f'build did not produce {artifact}'
+    with open(os.path.join(build_dir, _COMPLETE_MARKER), 'w') as f:
+        # Provenance, for diagnosing entries built on other machines.
+        f.write(f'artifact={os.path.basename(artifact)}\n')
+        f.write(f'torch={torch.__version__}\n')
+        f.write(f'cuda_runtime={torch.version.cuda}\n')
+        f.write(f'cuda_toolkit={toolkit_version() or "unknown"}\n')
+
+def clean_failed_build(build_dir, module_name):
+    """Delete an incomplete entry (interrupted or failed build) so the next
+    build starts from scratch."""
+    if os.path.isdir(build_dir) and not is_complete(build_dir, module_name):
+        shutil.rmtree(build_dir, ignore_errors=True)
+
+#----------------------------------------------------------------------------
+# Source staging (atomic, timestamp-stable so ninja rebuilds stay incremental).
+
+def populate_sources(build_dir, source_files):
+    if os.path.isdir(build_dir):
+        return
+    tmpdir = os.path.join(os.path.dirname(build_dir), f'srctmp-{uuid.uuid4().hex}')
+    os.makedirs(tmpdir)
+    for src in source_files:
+        shutil.copyfile(src, os.path.join(tmpdir, os.path.basename(src)))
+    try:
+        os.replace(tmpdir, build_dir) # atomic
+    except OSError:
+        # Entry appeared concurrently; discard our copy.
+        shutil.rmtree(tmpdir)
+        if not os.path.isdir(build_dir):
+            raise
+
+#----------------------------------------------------------------------------
+# Loading a completed entry (no compiler, no CUDA toolkit, no ninja).
+
+def import_from_cache(module_name, build_dir):
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    filename = _artifact_path(build_dir, module_name)
+    loader = importlib.machinery.ExtensionFileLoader(module_name, filename)
+    spec = importlib.util.spec_from_file_location(module_name, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        loader.exec_module(module)
+    except ImportError as err:
+        del sys.modules[module_name]
+        try:
+            with open(os.path.join(build_dir, _COMPLETE_MARKER)) as f:
+                provenance = ', '.join(line.strip() for line in f if '=' in line)
+        except OSError:
+            provenance = 'unknown'
+        raise ImportError(f'{err}\nCached op failed to load; it may have been built for a different '
+                          f'environment ({provenance}). Ops built with a CUDA toolkit newer than the torch '
+                          f'runtime need a correspondingly recent GPU driver. Delete {build_dir} to force '
+                          f'a rebuild.') from err
+    return module
+
+#----------------------------------------------------------------------------
+# Compiler environment.
+
+def _find_compiler_bindir():
+    patterns = [
+        'C:/Program Files*/Microsoft Visual Studio/*/Professional/VC/Tools/MSVC/*/bin/Hostx64/x64',
+        'C:/Program Files*/Microsoft Visual Studio/*/BuildTools/VC/Tools/MSVC/*/bin/Hostx64/x64',
+        'C:/Program Files*/Microsoft Visual Studio/*/Community/VC/Tools/MSVC/*/bin/Hostx64/x64',
+        'C:/Program Files*/Microsoft Visual Studio */vc/bin',
+    ]
+    for pattern in patterns:
+        matches = sorted(glob.glob(pattern))
+        if len(matches):
+            return matches[-1]
+    return None
+
+def setup_compiler_env():
+    """Make sure the C++ compiler is reachable; raise if it cannot be found."""
+    if os.name == 'nt' and os.system('where cl.exe >nul 2>nul') != 0:
+        compiler_bindir = _find_compiler_bindir()
+        if compiler_bindir is None:
+            raise RuntimeError(f'Could not find MSVC/GCC/CLANG installation on this computer. Check _find_compiler_bindir() in "{__file__}".')
+        os.environ['PATH'] += ';' + compiler_bindir
+
+def toolkit_version():
+    """Version of the CUDA toolkit that nvcc builds with (e.g. '12.8'),
+    or None if no toolkit can be found. This can differ from
+    torch.version.cuda, the runtime torch was built against."""
+    cuda_home = torch.utils.cpp_extension._find_cuda_home() # pylint: disable=protected-access
+    if cuda_home is None:
+        return None
+    try:
+        output = subprocess.check_output([os.path.join(cuda_home, 'bin', 'nvcc'), '--version']).decode()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    match = re.search(r'release (\d+\.\d+)', output)
+    return match.group(1) if match else None
+
+def pin_arch_list(capability=None):
+    # Match upstream custom_ops: an empty TORCH_CUDA_ARCH_LIST makes nvcc
+    # target the current device, and overriding neutralizes container-set
+    # values that could break the build or target the wrong archs. The
+    # precompile script passes an explicit capability to cross-build.
+    os.environ['TORCH_CUDA_ARCH_LIST'] = capability if capability is not None else ''
+
+def toolkit_mismatch():
+    """(toolkit, runtime) versions when their majors differ, else None."""
+    toolkit = toolkit_version()
+    runtime = torch.version.cuda
+    if toolkit is None or runtime is None or toolkit.split('.')[0] == runtime.split('.')[0]:
+        return None
+    return toolkit, runtime
+
+def warn_toolkit_mismatch():
+    """Print the toolkit/runtime mismatch warning once per process."""
+    mismatch = toolkit_mismatch()
+    if mismatch is not None and not getattr(warn_toolkit_mismatch, '_warned', False):
+        warn_toolkit_mismatch._warned = True
+        toolkit, runtime = mismatch
+        print(f'Warning: building with CUDA toolkit {toolkit} but torch runs CUDA {runtime}. '
+              f'This works, but the built ops embed the CUDA {toolkit.split(".")[0]} runtime and need a '
+              f'correspondingly recent GPU driver on every machine that loads them. Prefer a CUDA '
+              f'{runtime.split(".")[0]}.x toolkit (set CUDA_HOME/CUDA_PATH to select one).', file=sys.stderr)
+    return mismatch
+
+#----------------------------------------------------------------------------

--- a/torch_utils/custom_ops.py
+++ b/torch_utils/custom_ops.py
@@ -6,89 +6,20 @@
 # distribution of this software and related documentation without an express
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
-import hashlib
 import importlib
-import importlib.util
+import logging
 import os
-import re
-import shutil
-import uuid
 import traceback
+
 import torch
 import torch.utils.cpp_extension
-import subprocess
+
+from torch_utils import build_cache
 
 #----------------------------------------------------------------------------
 # Global options.
 
 verbosity = 'brief' # Verbosity level: 'none', 'brief', 'full'
-
-#----------------------------------------------------------------------------
-# Internal helper funcs.
-
-_msvc_env_activated = False
-
-def _activate_msvc_env():
-    global _msvc_env_activated
-    if os.name != 'nt':
-        return True
-    if _msvc_env_activated or 'VSCMD_ARG_TGT_ARCH' in os.environ:
-        return True
-    if shutil.which('cl'):
-        return True
-
-    vswhere = r'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe'
-    if not os.path.isfile(vswhere):
-        return False
-
-    try:
-        result = subprocess.run(
-            [vswhere, '-latest', '-products', '*',
-             '-requires', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
-             '-property', 'installationPath'],
-            capture_output=True, text=True, check=True
-        )
-        vs_path = result.stdout.strip()
-        if not vs_path:
-            return False
-    except Exception:
-        return False
-
-    vcvarsall = os.path.join(vs_path, 'VC', 'Auxiliary', 'Build', 'vcvarsall.bat')
-    if not os.path.isfile(vcvarsall):
-        return False
-
-    try:
-        out = subprocess.check_output(
-            f'cmd /u /c "{vcvarsall}" x64 && set',
-            stderr=subprocess.STDOUT,
-        ).decode('utf-16le', errors='replace')
-    except subprocess.CalledProcessError:
-        return False
-
-    for line in out.splitlines():
-        key, _, value = line.partition('=')
-        if key and value:
-            os.environ[key] = value
-
-    _msvc_env_activated = True
-    return True
-
-
-
-#----------------------------------------------------------------------------
-
-def _get_mangled_gpu_name():
-    if not torch.cuda.is_available():
-        return 'cpu'
-    name = torch.cuda.get_device_name().lower()
-    out = []
-    for c in name:
-        if re.match('[a-z0-9_-]+', c):
-            out.append(c)
-        else:
-            out.append('-')
-    return ''.join(out)
 
 #----------------------------------------------------------------------------
 # Main entry point for compiling and loading C++/CUDA plugins.
@@ -116,97 +47,49 @@ def get_plugin(module_name, sources, headers=None, source_dir=None, **build_kwar
 
     # Compile and load.
     try: # pylint: disable=too-many-nested-blocks
-        # Make sure we can find the necessary compiler binaries.
-        if os.name == 'nt' and not _activate_msvc_env():
-            print('Could not find MSVC installation. Install Visual Studio Build Tools with the C++ workload.')
-            return None
-
-        # Some containers set TORCH_CUDA_ARCH_LIST to a list that can either
-        # break the build or unnecessarily restrict what's available to nvcc.
-        # Unset it to let nvcc decide based on what's available on the
-        # machine.
-        os.environ['TORCH_CUDA_ARCH_LIST'] = ''
-
-        # Incremental build md5sum trickery.  Copies all the input source files
-        # into a cached build directory under a combined md5 digest of the input
-        # source files.  Copying is done only if the combined digest has changed.
-        # This keeps input file timestamps and filenames the same as in previous
-        # extension builds, allowing for fast incremental rebuilds.
-        #
-        # This optimization is done only in case all the source files reside in
-        # a single directory (just for simplicity) and if the TORCH_EXTENSIONS_DIR
-        # environment variable is set (we take this as a signal that the user
-        # actually cares about this.)
-        #
-        # EDIT: We now do it regardless of TORCH_EXTENSIOS_DIR, in order to work
-        # around the *.cu dependency bug in ninja config.
-        #
+        # Build into the shared cache keyed by (source digest, torch version,
+        # compute capabilities). Sources are copied into the cache entry so
+        # file timestamps and names stay stable across builds, allowing fast
+        # incremental rebuilds (and working around the *.cu dependency bug
+        # in ninja config). This requires all source files to reside in a
+        # single directory (just for simplicity).
         all_source_files = sorted(sources + headers)
         all_source_dirs = set(os.path.dirname(fname) for fname in all_source_files)
-        if len(all_source_dirs) == 1: # and ('TORCH_EXTENSIONS_DIR' in os.environ):
-
-            # Compute combined hash digest for all source files.
-            hash_md5 = hashlib.md5()
-            for src in all_source_files:
-                with open(src, 'rb') as f:
-                    hash_md5.update(f.read())
-
-            # Select cached build directory name.
-            source_digest = hash_md5.hexdigest()
-            build_top_dir = torch.utils.cpp_extension._get_build_directory(module_name, verbose=verbose_build) # pylint: disable=protected-access
-            cached_build_dir = os.path.join(build_top_dir, f'{source_digest}-{_get_mangled_gpu_name()}')
-
-            if os.path.isdir(cached_build_dir):
-                compiled_file = None
-                for ext in ['.pyd', '.so']:
-                    candidate = os.path.join(cached_build_dir, f'{module_name}{ext}')
-                    if os.path.isfile(candidate):
-                        compiled_file = candidate
-                        break
-
-                if compiled_file is not None:
-                    try:
-                        spec = importlib.util.spec_from_file_location(module_name, compiled_file)
-                        module = importlib.util.module_from_spec(spec)
-                        spec.loader.exec_module(module)
-                        if verbosity != 'none':
-                            print(f'Loaded cached PyTorch plugin "{module_name}".')
-                        _cached_plugins[module_name] = module
-                        return module
-                    except Exception as e:
-                        if verbosity != 'none':
-                            print(f'Cached plugin "{module_name}" failed to load ({e}), rebuilding...')
-                else:
-                    if verbosity != 'none':
-                        print(f'Incomplete cache for plugin "{module_name}", deleting cache and rebuilding...')
-                    shutil.rmtree(cached_build_dir)
-
-            if not os.path.isdir(cached_build_dir):
-                tmpdir = f'{build_top_dir}/srctmp-{uuid.uuid4().hex}'
-                os.makedirs(tmpdir)
-                for src in all_source_files:
-                    shutil.copyfile(src, os.path.join(tmpdir, os.path.basename(src)))
-                try:
-                    os.replace(tmpdir, cached_build_dir) # atomic
-                except OSError:
-                    shutil.rmtree(tmpdir)
-                    if not os.path.isdir(cached_build_dir): return False
-
-            cached_sources = [os.path.join(cached_build_dir, os.path.basename(fname)) for fname in sources]
-            torch.utils.cpp_extension.load(name=module_name, build_directory=cached_build_dir,
-                verbose=verbose_build, sources=cached_sources, **build_kwargs)
+        if len(all_source_dirs) == 1:
+            capability = build_cache.current_capability()
+            # Any complete entry covering the current device works, including
+            # multi-arch entries produced by scripts/precompile_ops.py.
+            cached_build_dir = build_cache.find_compatible_build_dir(module_name, all_source_files, capability, verbose=verbose_build)
+            if cached_build_dir is None:
+                cached_build_dir = build_cache.plugin_build_dir(module_name, all_source_files, [capability], verbose=verbose_build)
+                # Failed or abandoned entries poison the cache; remove them
+                # before building. The compiler is only required on this path.
+                build_cache.clean_failed_build(cached_build_dir, module_name)
+                build_cache.setup_compiler_env()
+                build_cache.warn_toolkit_mismatch()
+                build_cache.pin_arch_list()
+                build_cache.populate_sources(cached_build_dir, all_source_files)
+                cached_sources = [os.path.join(cached_build_dir, os.path.basename(fname)) for fname in sources]
+                torch.utils.cpp_extension.load(name=module_name, build_directory=cached_build_dir,
+                    verbose=verbose_build, sources=cached_sources, **build_kwargs)
+                build_cache.mark_complete(cached_build_dir, module_name)
+            # A complete entry (JIT-warmed or precompiled) loads directly,
+            # without compiler or CUDA toolkit access.
+            module = build_cache.import_from_cache(module_name, cached_build_dir)
         else:
+            build_cache.setup_compiler_env()
+            build_cache.warn_toolkit_mismatch()
+            build_cache.pin_arch_list()
             torch.utils.cpp_extension.load(name=module_name, verbose=verbose_build, sources=sources, **build_kwargs)
+            module = importlib.import_module(module_name)
 
-        # Load.
-        module = importlib.import_module(module_name)
-
-    except Exception as e:
+    except Exception:
         if verbosity == 'brief':
             print('Failed!')
-        print('Failed!')
-        print(f"Error details: {str(e)}")
-        print(f"Traceback: {traceback.format_exc()}")
+        logging.getLogger(__name__).warning(
+            'Failed to set up PyTorch plugin "%s"; the ops that use it fall back to their slow '
+            'reference implementation. Details:\n\n%s', module_name, traceback.format_exc())
+        _cached_plugins[module_name] = None
         return None
 
     # Print status and add to cache dict.

--- a/torch_utils/ops/bias_act.py
+++ b/torch_utils/ops/bias_act.py
@@ -45,7 +45,7 @@ def _init():
             source_dir=os.path.dirname(__file__),
             extra_cuda_cflags=['--use_fast_math', '--allow-unsupported-compiler'],
         )
-    return True
+    return _plugin is not None
 
 #----------------------------------------------------------------------------
 

--- a/torch_utils/ops/filtered_lrelu.py
+++ b/torch_utils/ops/filtered_lrelu.py
@@ -30,7 +30,7 @@ def _init():
             source_dir=os.path.dirname(__file__),
             extra_cuda_cflags=['--use_fast_math', '--allow-unsupported-compiler'],
         )
-    return True
+    return _plugin is not None
 
 def _get_filter_size(f):
     if f is None:

--- a/torch_utils/ops/upfirdn2d.py
+++ b/torch_utils/ops/upfirdn2d.py
@@ -30,7 +30,7 @@ def _init():
             source_dir=os.path.dirname(__file__),
             extra_cuda_cflags=['--use_fast_math', '--allow-unsupported-compiler'],
         )
-    return True
+    return _plugin is not None
 
 def _parse_scaling(scaling):
     if isinstance(scaling, int):

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 resolution-markers = [
     "platform_machine == 'aarch64' and sys_platform == 'linux'",
@@ -94,7 +94,7 @@ dependencies = [
     { name = "ninja" },
     { name = "numpy" },
     { name = "openai-clip" },
-    { name = "opencv-python" },
+    { name = "opencv-python-headless" },
     { name = "opensimplex" },
     { name = "pillow" },
     { name = "psutil" },
@@ -142,7 +142,7 @@ requires-dist = [
     { name = "ninja", specifier = "==1.11.1.1" },
     { name = "numpy", specifier = "==1.26.4" },
     { name = "openai-clip", specifier = "==1.0.1" },
-    { name = "opencv-python", specifier = "==4.8.1.78" },
+    { name = "opencv-python-headless", specifier = "==4.8.1.78" },
     { name = "opensimplex", specifier = "==0.4.5" },
     { name = "pillow", specifier = "==10.4.0" },
     { name = "psutil", specifier = ">=6.0.0" },
@@ -699,7 +699,7 @@ name = "macholib"
 version = "1.16.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "altgraph", marker = "sys_platform == 'darwin'" },
+    { name = "altgraph" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
 wheels = [
@@ -921,7 +921,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -932,7 +932,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -959,9 +959,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "nvidia-cusparse-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -972,7 +972,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -1031,20 +1031,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3f/81/26d701ef9fface424b4ca808a5c5674df645ac46447720a540143d11c41e/openai-clip-1.0.1.tar.gz", hash = "sha256:cd40bf2f205c096c49524fcbff484339f793b52afd6e7ffad80a2fe108151721", size = 1371625, upload-time = "2022-07-19T12:56:52.824Z" }
 
 [[package]]
-name = "opencv-python"
+name = "opencv-python-headless"
 version = "4.8.1.78"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/52/9fe76a56e01078a612812b40764a7b138f528b503f7653996c6cfadfa8ec/opencv-python-4.8.1.78.tar.gz", hash = "sha256:cc7adbbcd1112877a39274106cb2752e04984bc01a031162952e97450d6117f6", size = 92094255, upload-time = "2023-09-28T11:10:40.539Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/3a/062caf910026a174b15a24b959bc401e756fda7f42d9d404dec8b166f359/opencv-python-headless-4.8.1.78.tar.gz", hash = "sha256:bc7197b42352f6f865c302a49140b889ec7cd957dd697e2d7fc016ad0d3f28f1", size = 92110982, upload-time = "2023-09-28T11:12:10.394Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/58/7ee92b21cb98689cbe28c69e3cf8ee51f261bfb6bc904ae578736d22d2e7/opencv_python-4.8.1.78-cp37-abi3-macosx_10_16_x86_64.whl", hash = "sha256:91d5f6f5209dc2635d496f6b8ca6573ecdad051a09e6b5de4c399b8e673c60da", size = 54739488, upload-time = "2023-09-28T11:00:22.939Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/f6/57de91ea40c670527cd47a6548bf2cbedc68cec57c041793b256356abad7/opencv_python-4.8.1.78-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:bc31f47e05447da8b3089faa0a07ffe80e114c91ce0b171e6424f9badbd1c5cd", size = 33127231, upload-time = "2023-09-28T11:00:31.878Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/a5/dd3735d08c1afc2e801f564f6602392cd86cf59bcb5a6712582ad0610a22/opencv_python-4.8.1.78-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9814beca408d3a0eca1bae7e3e5be68b07c17ecceb392b94170881216e09b319", size = 41016265, upload-time = "2023-09-28T11:00:39.652Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/8a/b2f7e1a434d56bf1d7570fc5941ace0847404e1032d7f1f0b8fed896568d/opencv_python-4.8.1.78-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c4c406bdb41eb21ea51b4e90dfbc989c002786c3f601c236a99c59a54670a394", size = 61712178, upload-time = "2023-09-28T11:00:49.714Z" },
-    { url = "https://files.pythonhosted.org/packages/13/92/6f3194559d4e2a17826240f2466076728f4c92a2d124a32bfd51ca070019/opencv_python-4.8.1.78-cp37-abi3-win32.whl", hash = "sha256:a7aac3900fbacf55b551e7b53626c3dad4c71ce85643645c43e91fcb19045e47", size = 28281329, upload-time = "2023-09-28T11:00:57.464Z" },
-    { url = "https://files.pythonhosted.org/packages/38/d2/3e8c13ffc37ca5ebc6f382b242b44acb43eb489042e1728407ac3904e72f/opencv_python-4.8.1.78-cp37-abi3-win_amd64.whl", hash = "sha256:b983197f97cfa6fcb74e1da1802c7497a6f94ed561aba6980f1f33123f904956", size = 38065100, upload-time = "2023-09-28T11:01:04.856Z" },
+    { url = "https://files.pythonhosted.org/packages/49/89/1bb0c2847749517c4f3d2a35f5650f8109009c078d41ceb58cbd191a01c6/opencv_python_headless-4.8.1.78-cp37-abi3-macosx_10_16_x86_64.whl", hash = "sha256:f3a33f644249f9ce1c913eac580e4b3ef4ce7cab0a71900274708959c2feb5e3", size = 54739610, upload-time = "2023-09-28T11:03:45.306Z" },
+    { url = "https://files.pythonhosted.org/packages/12/0f/b87324db284c54d1d1a1c1242a128fb18515915d124325784c90f23d8ef5/opencv_python_headless-4.8.1.78-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:2c7d45721df9801c4dcd34683a15caa0e30f38b185263fec04a6eb274bc720f0", size = 33127329, upload-time = "2023-09-28T11:03:53.522Z" },
+    { url = "https://files.pythonhosted.org/packages/70/cf/205f6e18dddaa75375d34d809788708b1f1d4ce747194de511274fe6bd0a/opencv_python_headless-4.8.1.78-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b6bd6e1132b6f5dcb3a5bfe30fc4d341a7bfb26134da349a06c9255288ded94", size = 28686712, upload-time = "2023-09-28T11:03:59.992Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/d7/e2aaf344254292d2046f9984b54212e4e7d69a57d30ae15e7294840710f6/opencv_python_headless-4.8.1.78-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58e70d2f0915fe23e02c6e405588276c9397844a47d38b9c87fac5f7f9ba2dcc", size = 49104508, upload-time = "2023-09-28T11:04:08.696Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/1a/ed64e92a26c2ee89599686e4cab54602e4387beb7844c012804b46c31a55/opencv_python_headless-4.8.1.78-cp37-abi3-win32.whl", hash = "sha256:382f8c7a6a14f80091284eecedd52cee4812231ee0eff1118592197b538d9252", size = 28205128, upload-time = "2023-09-28T11:04:15.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/10/31b27a7473043eb5317f698ede00e7e129b2de378903bfe0bb4d785a7baf/opencv_python_headless-4.8.1.78-cp37-abi3-win_amd64.whl", hash = "sha256:0a0f1e9f836f7d5bad1dd164694944c8761711cbdf4b36ebbd4815a8ef731079", size = 37968155, upload-time = "2023-09-28T11:04:22.896Z" },
 ]
 
 [[package]]
@@ -1694,13 +1694,13 @@ resolution-markers = [
     "sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "sys_platform == 'darwin'" },
-    { name = "networkx", marker = "sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "sys_platform == 'darwin'" },
-    { name = "sympy", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/66/5c9a321b325aaecb92d4d1855421e3a055abd77903b7dab6575ca07796db/torch-2.8.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:619c2869db3ada2c0105487ba21b5008defcc472d23f8b80ed91ac4a380283b0", size = 73630478, upload-time = "2025-08-06T14:53:57.144Z" },
@@ -1715,10 +1715,10 @@ resolution-markers = [
     "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform != 'darwin'" },
-    { name = "fsspec", marker = "sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "sys_platform != 'darwin'" },
-    { name = "networkx", marker = "sys_platform != 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
     { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -1733,10 +1733,10 @@ dependencies = [
     { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setuptools", marker = "sys_platform != 'darwin'" },
-    { name = "sympy", marker = "sys_platform != 'darwin'" },
+    { name = "setuptools" },
+    { name = "sympy" },
     { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4354fc05bb79b208d6995a04ca1ceef6a9547b1c4334435574353d381c55087c", upload-time = "2025-10-01T23:51:02Z" },
@@ -1751,7 +1751,7 @@ resolution-markers = [
     "sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "torch", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/cc/c2e2a3eb6ee956f73c68541e439916f8146170ea9cc61e72adea5c995312/torchaudio-2.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ddef94bf181e6447cbb05f38beaca8f6c5bb8d2b9ddced1aa3452025b9fc70d3", size = 1856736, upload-time = "2025-08-06T14:58:36.3Z" },
@@ -1766,7 +1766,7 @@ resolution-markers = [
     "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "torch", version = "2.8.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.8.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.8.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:145b8a0c21cfcaa1705c67173c5d439087e0e120d5da9bc344746f937901d243", upload-time = "2025-08-05T20:12:07Z" },
@@ -1781,9 +1781,9 @@ resolution-markers = [
     "sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'darwin'" },
-    { name = "pillow", marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/1d/0ea0b34bde92a86d42620f29baa6dcbb5c2fc85990316df5cb8f7abb8ea2/torchvision-0.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e0e2c04a91403e8dd3af9756c6a024a1d9c0ed9c0d592a8314ded8f4fe30d440", size = 1856885, upload-time = "2025-08-06T14:58:06.503Z" },
@@ -1798,9 +1798,9 @@ resolution-markers = [
     "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'darwin'" },
-    { name = "pillow", marker = "sys_platform != 'darwin'" },
-    { name = "torch", version = "2.8.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform != 'darwin'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.8.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.23.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:9cb3c13997afcb44057ca10d943c6c4cba3068afde0f370965abce9c89fcffa9", upload-time = "2025-08-05T20:11:52Z" },
@@ -1824,7 +1824,7 @@ name = "triton"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "setuptools" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/66/b1eb52839f563623d185f0927eb3530ee4d5ffe9d377cdaf5346b306689e/triton-3.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31c1d84a5c0ec2c0f8e8a072d7fd150cab84a9c239eaddc6706c081bfae4eb04", size = 155560068, upload-time = "2025-07-30T19:58:37.081Z" },


### PR DESCRIPTION
## Summary

- Replace the custom-ops loader with the build-cache implementation: cache entries are keyed by source digest, Python/torch version, and compute capabilities, so they can be precompiled at release time and loaded on user machines without MSVC or the CUDA toolkit.
- `scripts/precompile_ops.py` builds multi-arch entries for SM 7.5 / 8.6 / 8.9 / 12.0 (RTX 20–50 series) and exports stripped entries (artifact + completion marker) that `release.py` bundles into `_internal/torch_extensions`.
- Three-tier fallback at runtime: cached ops → JIT build → slow reference ops. Incomplete cache entries (e.g. from an interrupted build) are deleted and rebuilt.
- Bundle size reductions: allowlist the six torch import libs actually needed for JIT linking, prune unreachable CUDA/cuDNN/ffmpeg binaries (verified by running training and inference without them), switch to ffmpeg essentials build and opencv-python-headless. The xz-compressed release archive now fits under GitHub's release asset size limit.

## Testing

Manually tested on Windows: release build loads the precompiled ops with no compiler installed, JIT fallback and reference-ops fallback both exercised, training and inference run against the pruned bundle.