### PR TITLE
feat: continuous osc latent navigation

### DIFF
--- a/docs/perform.md
+++ b/docs/perform.md
@@ -44,6 +44,7 @@ In this mode, the latent space is controlled using seed numbers, each correspond
 
 - Project: StyleGAN has a feature that maps latent vectors into a more desirable space. By toggling this off, you might receive less consistent results.
 - Seed: The seed is a number that is used to generate a latent vector. By changing the seed you can explore different points in the latent space.
+- X and Y: The exact position in the latent space. Whole numbers land exactly on a seed. Values in between smoothly blend the neighboring seeds. These are the values to target when binding OSC for smooth latent motion.
 - Drag: By dragging after clicking the button you can explore the latent space. This incrementally changes the seed.
 - Anim/Stop: Starts/stops animating a continuous movement in the latent space.
 - Speed: Controls the speed of the animation.

--- a/tests/test_latent_widget_osc.py
+++ b/tests/test_latent_widget_osc.py
@@ -1,0 +1,68 @@
+from widgets.latent_widget import LatentWidget
+
+
+class StubDispatcher:
+    def map(self, address, func):
+        pass
+
+    def unmap(self, address, func):
+        pass
+
+
+class StubViz:
+    def __init__(self):
+        self.osc_dispatcher = StubDispatcher()
+        self.errors = []
+
+    def print_error(self, e):
+        self.errors.append(e)
+
+
+def make_widget():
+    return LatentWidget(StubViz())
+
+
+def test_coordinates_initialize_as_floats():
+    w = make_widget()
+    assert isinstance(w.latent.x, float)
+    assert isinstance(w.latent.y, float)
+
+
+def test_seed_handler_stores_fractional_values():
+    w = make_widget()
+    w.osc_handler("x", float)("/seed", 3.5)
+    assert w.latent.x == 3.5
+    assert w.viz.errors == []
+
+
+def test_seed_handler_stays_float_after_int_assignment():
+    w = make_widget()
+    w.latent.x = 7
+    w.osc_handler("x", float)("/seed", 2.25)
+    assert w.latent.x == 2.25
+    assert isinstance(w.latent.x, float)
+
+
+def test_seed_y_handler_writes_y():
+    w = make_widget()
+    w.osc_handler("y", float)("/pad/y", 1.75)
+    assert w.latent.y == 1.75
+
+
+def test_seed_menu_keys():
+    w = make_widget()
+    assert list(w.seed_osc_menu.funcs.keys()) == [
+        "project", "seed", "seed y", "anim", "speed", "model"]
+
+
+def test_vec_menu_has_no_seed_keys():
+    w = make_widget()
+    assert "seed" not in w.vec_osc_menu.funcs
+    assert "seed y" not in w.vec_osc_menu.funcs
+
+
+def test_seed_y_end_to_end_through_menu():
+    w = make_widget()
+    w.seed_osc_menu.use_osc["seed y"] = True
+    w.seed_osc_menu.funcs["seed y"]("/pad/y", 0.6)
+    assert w.latent.y == 0.6

--- a/tests/test_latent_widget_osc.py
+++ b/tests/test_latent_widget_osc.py
@@ -66,3 +66,14 @@ def test_seed_y_end_to_end_through_menu():
     w.seed_osc_menu.use_osc["seed y"] = True
     w.seed_osc_menu.funcs["seed y"]("/pad/y", 0.6)
     assert w.latent.y == 0.6
+
+
+def test_seed_mapping_expression_end_to_end():
+    w = make_widget()
+    menu = w.seed_osc_menu
+    menu.use_osc["seed"] = True
+    menu.mappings["seed"] = "x*20"
+    menu.wrapped_funcs["seed"] = menu.map_func(menu.funcs["seed"], "seed")
+    menu.wrapped_funcs["seed"]("/fader", 0.25)
+    assert w.latent.x == 5.0
+    assert w.viz.errors == []

--- a/tests/test_osc_menu.py
+++ b/tests/test_osc_menu.py
@@ -1,0 +1,72 @@
+import pickle
+
+from widgets.osc_menu import OscMenu
+
+
+class StubDispatcher:
+    def __init__(self):
+        self.mapped = []
+
+    def map(self, address, func):
+        self.mapped.append((address, func))
+
+    def unmap(self, address, func):
+        pass
+
+
+class StubViz:
+    def __init__(self):
+        self.osc_dispatcher = StubDispatcher()
+        self.errors = []
+
+    def print_error(self, e):
+        self.errors.append(e)
+
+
+def record(address, *args):
+    pass
+
+
+def test_set_params_backfills_missing_keys():
+    viz = StubViz()
+    old_menu = OscMenu(viz, {"seed": record}, label="##old")
+    params = pickle.loads(pickle.dumps(old_menu.get_params()))
+
+    new_menu = OscMenu(viz, {"seed": record, "seed y": record}, label="##new")
+    new_menu.set_params(params)
+
+    assert new_menu.use_osc["seed y"] is False
+    assert new_menu.osc_addresses["seed y"] == "..."
+    assert new_menu.cached_osc_addresses["seed y"] == "..."
+    assert new_menu.mappings["seed y"] == "x"
+    assert new_menu.use_map["seed y"] is True
+
+
+def test_set_params_preserves_loaded_values():
+    viz = StubViz()
+    old_menu = OscMenu(viz, {"seed": record}, label="##old")
+    old_menu.use_osc["seed"] = True
+    old_menu.osc_addresses["seed"] = "fader1"
+    old_menu.cached_osc_addresses["seed"] = "fader1"
+    old_menu.mappings["seed"] = "x*20"
+    params = pickle.loads(pickle.dumps(old_menu.get_params()))
+
+    new_menu = OscMenu(viz, {"seed": record, "seed y": record}, label="##new")
+    new_menu.set_params(params)
+
+    assert new_menu.use_osc["seed"] is True
+    assert new_menu.osc_addresses["seed"] == "fader1"
+    assert new_menu.mappings["seed"] == "x*20"
+    mapped_addresses = [address for address, _ in viz.osc_dispatcher.mapped]
+    assert "/fader1" in mapped_addresses
+
+
+def test_backfilled_key_receives_without_error():
+    viz = StubViz()
+    old_menu = OscMenu(viz, {"seed": record}, label="##old")
+    params = pickle.loads(pickle.dumps(old_menu.get_params()))
+
+    new_menu = OscMenu(viz, {"seed": record, "seed y": record}, label="##new")
+    new_menu.set_params(params)
+
+    new_menu.funcs["seed y"]("/pad/y", 0.5)

--- a/widgets/latent_widget.py
+++ b/widgets/latent_widget.py
@@ -36,17 +36,21 @@ modes = ["Stop", "Anim"]
 class LatentWidget:
     def __init__(self, viz):
         self.viz        = viz
-        self.latent = dnnlib.EasyDict(vec=torch.randn(1, 512), next=torch.randn(1, 512), x=0, y=0, frac_x=0., frac_y=0.,
+        self.latent = dnnlib.EasyDict(vec=torch.randn(1, 512), next=torch.randn(1, 512), x=0.0, y=0.0,
                                       update_mode=0, speed=0.25, mode=True, project=True)
         self.step_y = 100
-        funcs = dict(zip(["project", "seed",  "anim", "speed"],
-                         [self.osc_handler(param) for param in
-                          ["project", "x", "update_mode", "speed"]]))
-        funcs["speed"] = self.speed_handler()
-        funcs["model"] = self.model_handler()
+        funcs = {
+            "project": self.osc_handler("project", bool),
+            "seed": self.osc_handler("x", float),
+            "seed y": self.osc_handler("y", float),
+            "anim": self.osc_handler("update_mode", int),
+            "speed": self.speed_handler(),
+            "model": self.model_handler(),
+        }
         self.seed_osc_menu = osc_menu.OscMenu(self.viz, copy.deepcopy(funcs),
                                          label="##SeedOSC")
         del funcs["seed"]
+        del funcs["seed y"]
         funcs["vector"] = self.list_handler("vec")
         funcs["randomize"] = self.randomize_handler()
         self.vec_osc_menu = osc_menu.OscMenu(self.viz, copy.deepcopy(funcs),
@@ -84,11 +88,10 @@ class LatentWidget:
         self.latent.x += dx / viz.app.font_size * 4e-2
         self.latent.y += dy / viz.app.font_size * 4e-2
 
-    def osc_handler(self, param):
+    def osc_handler(self, param, ptype):
         def func(address, *args):
             try:
-                nec_type = type(self.latent[param])
-                self.latent[param] = nec_type(args[-1])
+                self.latent[param] = ptype(args[-1])
             except Exception as e:
                 self.viz.print_error(e)
         return func

--- a/widgets/latent_widget.py
+++ b/widgets/latent_widget.py
@@ -125,17 +125,16 @@ class LatentWidget:
         with imgui_utils.item_width(viz.app.font_size * 8):
             _changed, seed = imgui.input_int("##seed", seed)
         if _changed:
-            self.latent.x = seed
-            self.latent.y = 0
+            self.latent.x = float(seed)
+            self.latent.y = 0.0
         imgui.same_line()
-        frac_x = self.latent.x - round(self.latent.x)
-        frac_y = self.latent.y - round(self.latent.y)
         with imgui_utils.item_width(viz.app.font_size * 5):
-            _changed, (new_frac_x, new_frac_y) = imgui.input_float2('##frac', frac_x, frac_y, format='%+.2f',
-                                                                    flags=imgui.INPUT_TEXT_ENTER_RETURNS_TRUE)
+            _changed, (new_x, new_y) = imgui.input_float2('##xy', self.latent.x, self.latent.y,
+                                                          format='%.2f',
+                                                          flags=imgui.INPUT_TEXT_ENTER_RETURNS_TRUE)
         if _changed:
-            self.latent.x += new_frac_x - frac_x
-            self.latent.y += new_frac_y - frac_y
+            self.latent.x = new_x
+            self.latent.y = new_y
         imgui.same_line(spacing=0)
         _clicked, dragging, dx, dy = imgui_utils.drag_button('Drag', width=viz.app.button_w)
         if dragging:

--- a/widgets/osc_menu.py
+++ b/widgets/osc_menu.py
@@ -58,6 +58,12 @@ class OscMenu:
 
     def set_params(self, params):
         self.use_map, self.use_osc, self.osc_addresses, self.cached_osc_addresses, self.mappings = params
+        for key in self.funcs.keys():
+            self.use_map.setdefault(key, True)
+            self.use_osc.setdefault(key, False)
+            self.osc_addresses.setdefault(key, "...")
+            self.cached_osc_addresses.setdefault(key, "...")
+            self.mappings.setdefault(key, "x")
         for key, func in self.funcs.items():
             self.funcs[key] = self.check_osc(func, key)
         for key, func in self.funcs.items():


### PR DESCRIPTION
## Summary

OSC-bound parameters can now navigate the latent seed space continuously instead of jumping between integer seeds. The `seed` binding accepts fractional values, a new `seed y` binding exposes the second grid axis, and the seed-mode UI shows the absolute X/Y coordinates (the same values OSC writes) instead of fractional offsets. The renderer needed no changes: it already bilinearly blends the 4 seeds around a fractional coordinate.

Details:
- `osc_handler` now casts with an explicit type per binding instead of the runtime type of the target, which is what truncated OSC values to integers (`latent.x` started as int and was reset to int by the seed box).
- `OscMenu.set_params` backfills state-dict keys missing from older presets, so presets saved before the `seed y` key existed load cleanly (and any future key addition is preset-safe).
- The seed integer box is kept: it remains a lossless readout of the nearest seed and typing a seed still jumps to it.

Usage: bind a fader to `seed` with a mapping expression like `x*20` for a smooth sweep through 20 seeds, or an XY pad to `seed` + `seed y` for 2D roaming.

## Type of change

- [x] Feature
- [ ] Fix
- [ ] Other (docs, refactor, chore, ci, etc.)

## How was this tested?

Verified by automated tests and static checks:
- 11 new headless unit tests (`tests/test_osc_menu.py`, `tests/test_latent_widget_osc.py`): float storage through the handlers, type stability after int assignment, exact OSC menu key sets, end-to-end delivery through the menu wrapper including a mapping expression (`x*20`), and preset backfill round-tripped through pickle. Full suite: 26 passed.
- `uv run zensical build` passes for the docs change.
- Traced the render path: `viz.args.seeds` flows into the existing bilinear seed blending in `widgets/renderer.py` unchanged; fractional, negative, and large values all resolve to valid seeds.

Still needs manual GUI verification (cannot be driven headlessly):
- [ ] Bind an OSC fader to `seed` with mapping `x*5`, sweep 0 to 1: image morphs continuously, no jumps at integer boundaries.
- [ ] Bind an XY pad to `seed` and `seed y`: smooth 2D roaming.
- [ ] Seed box readout tracks X/Y edits and Drag; typing a seed jumps to it and resets Y to 0.
- [ ] Save a preset with active OSC bindings and reload it: bindings intact.
- [ ] Load a preset saved before this change: no errors, `seed y` appears in the OSC menu with defaults.
- [ ] Re-capture `docs/assets/live-module-latent-space-01.png` (still shows the old fractional boxes).

## Checklist

- [x] PR title follows Conventional Commits without a scope (`<type>: <subject>`)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Documentation in `docs/` or `README.md` is updated if user-visible behavior changed
- [x] If this PR adds new runtime files, they are included in `release.py` (no new runtime files)
- [ ] Screenshots or a short clip are attached for UI changes (pending manual verification pass)

Co-authored with an AI coding tool.

Generated with AI assistance