### PR TITLE
fix: correct mouse wheel scroll speed and child dead zones

### DIFF
--- a/tests/test_imgui_child_scroll.py
+++ b/tests/test_imgui_child_scroll.py
@@ -1,0 +1,115 @@
+import imgui
+import pytest
+
+from utils.gui_utils import imgui_utils
+
+
+class FakeImgui:
+    """Records begin_child flags and replays a scripted ScrollMax per label."""
+
+    def __init__(self, scroll_max):
+        self.scroll_max = scroll_max
+        self.calls = []
+        self._stack = []
+
+    def begin_child(self, label, width, height, border, flags):
+        self.calls.append((label, flags))
+        self._stack.append(label)
+
+    def get_scroll_max_y(self):
+        return self.scroll_max.get(self._stack[-1], 0.0)
+
+    def end_child(self):
+        self._stack.pop()
+
+
+@pytest.fixture
+def fake(monkeypatch):
+    def install(scroll_max=None):
+        stub = FakeImgui(scroll_max or {})
+        for name in ('begin_child', 'get_scroll_max_y', 'end_child'):
+            monkeypatch.setattr(imgui_utils.imgui, name, getattr(stub, name))
+        return stub
+    imgui_utils._open_children.clear()
+    return install
+
+
+class Owner:
+    pass
+
+
+def frame(owner, label, flags=0):
+    imgui_utils.begin_child(owner, label, flags=flags)
+    imgui_utils.end_child()
+
+
+def test_unscrollable_child_lets_the_wheel_through(fake):
+    stub = fake()
+    frame(Owner(), '##list')
+    _, flags = stub.calls[0]
+    assert flags & imgui.WINDOW_NO_SCROLL_WITH_MOUSE
+
+
+def test_no_scrollbar_is_stripped_so_imgui_165_forwards_to_the_parent(fake):
+    # imgui 1.65 refuses to climb to the parent when the child sets NoScrollbar,
+    # so the flag has to go for the forwarding to actually happen.
+    stub = fake()
+    frame(Owner(), '##list2', flags=imgui.WINDOW_NO_SCROLLBAR | imgui.WINDOW_NO_SCROLL_WITH_MOUSE)
+    _, flags = stub.calls[0]
+    assert not flags & imgui.WINDOW_NO_SCROLLBAR
+
+
+def test_scrollable_child_keeps_the_wheel_on_the_next_frame(fake):
+    stub = fake({'##list': 120.0})
+    owner = Owner()
+    frame(owner, '##list')          # first frame: nothing known yet
+    frame(owner, '##list')          # second frame: last frame said it scrolls
+    assert stub.calls[0][1] & imgui.WINDOW_NO_SCROLL_WITH_MOUSE
+    assert not stub.calls[1][1] & imgui.WINDOW_NO_SCROLL_WITH_MOUSE
+
+
+def test_author_flags_are_restored_once_the_child_can_scroll(fake):
+    stub = fake({'##list2': 40.0})
+    owner = Owner()
+    author = imgui.WINDOW_NO_SCROLLBAR | imgui.WINDOW_NO_SCROLL_WITH_MOUSE
+    frame(owner, '##list2', flags=author)
+    frame(owner, '##list2', flags=author)
+    assert stub.calls[1][1] == author
+
+
+def test_child_becoming_empty_reopens_the_wheel(fake):
+    stub = fake({'##list': 120.0})
+    owner = Owner()
+    frame(owner, '##list')
+    frame(owner, '##list')
+    stub.scroll_max['##list'] = 0.0  # layers unloaded
+    frame(owner, '##list')
+    frame(owner, '##list')
+    assert stub.calls[3][1] & imgui.WINDOW_NO_SCROLL_WITH_MOUSE
+
+
+def test_same_label_in_two_widgets_does_not_share_state(fake):
+    # layer_widget and collapsable_layer both name their children ##list.
+    stub = fake({'##list': 0.0})
+    scrolls, empty = Owner(), Owner()
+    stub.scroll_max['##list'] = 120.0
+    frame(scrolls, '##list')
+    frame(scrolls, '##list')
+    stub.scroll_max['##list'] = 0.0
+    frame(empty, '##list')
+    frame(empty, '##list')
+    assert not stub.calls[1][1] & imgui.WINDOW_NO_SCROLL_WITH_MOUSE
+    assert stub.calls[3][1] & imgui.WINDOW_NO_SCROLL_WITH_MOUSE
+
+
+def test_nested_children_unwind_in_order(fake):
+    stub = fake({'##outer': 200.0, '##inner': 0.0})
+    owner = Owner()
+    for _ in range(2):
+        imgui_utils.begin_child(owner, '##outer')
+        imgui_utils.begin_child(owner, '##inner')
+        imgui_utils.end_child()
+        imgui_utils.end_child()
+    assert not imgui_utils._open_children
+    assert not stub.calls[2][1] & imgui.WINDOW_NO_SCROLL_WITH_MOUSE   # outer scrolls
+    assert stub.calls[3][1] & imgui.WINDOW_NO_SCROLL_WITH_MOUSE       # inner does not

--- a/utils/gui_utils/imgui_utils.py
+++ b/utils/gui_utils/imgui_utils.py
@@ -7,6 +7,8 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 
 import contextlib
+import weakref
+
 import imgui
 from assets.colors import *
 
@@ -115,6 +117,38 @@ def scoped_by_object_id(method):
         return res
 
     return decorator
+
+
+# ----------------------------------------------------------------------------
+# imgui 1.65 only passes the mouse wheel from a child up to its parent when the
+# child sets NoScrollWithMouse and not NoScrollbar. A child that simply has
+# nothing to scroll swallows the wheel instead, so every child covering the pane
+# becomes a dead band. Upstream fixed this in 1.72 by also passing it up when the
+# child's ScrollMax is 0; these wrappers reproduce that rule from the previous
+# frame's ScrollMax, keyed per owning widget because labels repeat across
+# widgets. Drop-in replacements for imgui.begin_child / imgui.end_child.
+#
+# Only for children whose content genuinely comes and goes. A child that is
+# always too short for its own padding reports a few pixels of ScrollMax while
+# holding nothing scrollable, so it reads as scrollable here and keeps
+# swallowing the wheel -- those should set NoScrollWithMouse themselves.
+
+_child_scrollable = weakref.WeakKeyDictionary()
+_open_children = []
+
+
+def begin_child(owner, label, width=0, height=0, border=False, flags=0):
+    scrollable = _child_scrollable.setdefault(owner, {})
+    if not scrollable.get(label, False):
+        flags = (flags | imgui.WINDOW_NO_SCROLL_WITH_MOUSE) & ~imgui.WINDOW_NO_SCROLLBAR
+    imgui.begin_child(label, width, height, border, flags)
+    _open_children.append((scrollable, label))
+
+
+def end_child():
+    scrollable, label = _open_children.pop()
+    scrollable[label] = imgui.get_scroll_max_y() > 0
+    imgui.end_child()
 
 
 # ----------------------------------------------------------------------------

--- a/utils/gui_utils/imgui_window.py
+++ b/utils/gui_utils/imgui_window.py
@@ -131,7 +131,6 @@ class ImguiWindow(glfw_window.GlfwWindow):
         super().begin_frame()
 
         # Process imgui events.
-        self._imgui_renderer.mouse_wheel_multiplier = self._cur_font_size / 10
         if self.content_width > 0 and self.content_height > 0:
             self._imgui_renderer.process_inputs()
         self._apply_pending_font_sizes()
@@ -190,10 +189,17 @@ def _refresh_font_texture(renderer, alpha8):
 #----------------------------------------------------------------------------
 # Wrapper class for GlfwRenderer to fix a mouse wheel bug on Linux.
 
+# GLFW does not normalize scroll deltas: Windows and X11 report one unit per
+# wheel notch, macOS reports the OS line rate (3 per notch) or, on precise
+# devices, points/10. imgui then scrolls by mouse_wheel * 5 * font_size, which
+# is already constant in DPI-independent units -- deriving the scale from the
+# font size would apply the display scale a second time. Both values put a wheel
+# notch at ~60 units, matching native scrolling.
+_MOUSE_WHEEL_SCALE = 0.25 if sys.platform == 'darwin' else 0.75
+
 class _GlfwRenderer(imgui.integrations.glfw.GlfwRenderer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.mouse_wheel_multiplier = 1
         # The base class only polls button state once per frame, so a click whose
         # press and release both happen between two frames (e.g. a trackpad tap,
         # or any click while the frame rate is low) is lost. Latch presses from
@@ -226,7 +232,11 @@ class _GlfwRenderer(imgui.integrations.glfw.GlfwRenderer):
                     self.io.mouse_pos = cx / xscale, cy / yscale
 
     def scroll_callback(self, window, x_offset, y_offset):
-        self.io.mouse_wheel += y_offset * self.mouse_wheel_multiplier
+        # Accumulate rather than assign: several scroll events can arrive between
+        # two frames, and imgui clears mouse_wheel at the end of each one.
+        # x_offset is dropped on purpose -- trackpads leak sideways deltas into
+        # vertical swipes, and nothing in the UI scrolls horizontally.
+        self.io.mouse_wheel += y_offset * _MOUSE_WHEEL_SCALE
 
     def refresh_font_texture(self):
         _refresh_font_texture(self, alpha8=False)

--- a/widgets/collapsable_layer.py
+++ b/widgets/collapsable_layer.py
@@ -207,7 +207,7 @@ class LayerWidget:
             imgui.push_style_color(imgui.COLOR_HEADER_ACTIVE, 0,0,0,0)
 
             imgui.begin_child('##list', width=width, height=height, border=True, flags=imgui.WINDOW_NO_SCROLLBAR|imgui.WINDOW_NO_INPUTS)
-            imgui.begin_child('##list2', width=width, height=self.viz.app.font_size * 1.75, border=False, flags=imgui.WINDOW_NO_SCROLLBAR|imgui.WINDOW_NO_SCROLL_WITH_MOUSE)
+            imgui_utils.begin_child(self, '##list2', width=width, height=self.viz.app.font_size * 1.75, border=False, flags=imgui.WINDOW_NO_SCROLLBAR|imgui.WINDOW_NO_SCROLL_WITH_MOUSE)
             imgui.set_cursor_pos((0, -1))
             if self.simplified:
                 imgui_utils.color_button("Simple", color=GREEN, width=(width // 2))
@@ -234,9 +234,9 @@ class LayerWidget:
                     self.simplified = False
                 imgui.pop_style_color(4)
             imgui.separator()
-            imgui.end_child()
-            imgui.begin_child('##list3', width=width, height=height - self.viz.app.font_size * 1.5, border=False,
-                              flags=imgui.WINDOW_ALWAYS_VERTICAL_SCROLLBAR)
+            imgui_utils.end_child()
+            imgui_utils.begin_child(self, '##list3', width=width, height=height - self.viz.app.font_size * 1.5, border=False,
+                                    flags=imgui.WINDOW_ALWAYS_VERTICAL_SCROLLBAR)
             checkbox_size = viz.app.font_size
             draw_list = imgui.get_window_draw_list()
             # List items.
@@ -480,12 +480,12 @@ class LayerWidget:
             # End list.
             if len(layers) == 0:
                 imgui.text_colored('No layers found', *LIGHTGRAY)
-            imgui.end_child()
+            imgui_utils.end_child()
             imgui.end_child()
             imgui.pop_style_color(6)
             # imgui.pop_style_var(1)
             imgui.same_line()
-            imgui.begin_child('##adjust', width=-1, height=height, border=True)
+            imgui_utils.begin_child(self, '##adjust', width=-1, height=height, border=True)
             tab_width = imgui.get_content_region_available_width() / 2
             if (self.tab is False) and (len(layers) > 0):
                 if self.has_transforms[layer.name]:
@@ -550,7 +550,7 @@ class LayerWidget:
                     if noise in self.has_osc:
                         if self.has_osc[noise]==False:
                             self.has_osc[noise] = self.noises[noise]["use_osc"]
-            imgui.end_child()
+            imgui_utils.end_child()
 
             if self.cur_layer is not None:
                 self.ratios[self.cur_layer] = ratio

--- a/widgets/layer_widget.py
+++ b/widgets/layer_widget.py
@@ -152,8 +152,8 @@ class LayerWidget:
             imgui.push_style_color(imgui.COLOR_HEADER, 0, 0, 0, 0)
             imgui.push_style_color(imgui.COLOR_HEADER_HOVERED, 0.16, 0.29, 0.48, 0.5)
             imgui.push_style_color(imgui.COLOR_HEADER_ACTIVE, 0.16, 0.29, 0.48, 0.9)
-            imgui.begin_child('##list', width=width, height=height, border=True,
-                              flags=imgui.WINDOW_ALWAYS_VERTICAL_SCROLLBAR)
+            imgui_utils.begin_child(self, '##list', width=width, height=height, border=True,
+                                    flags=imgui.WINDOW_ALWAYS_VERTICAL_SCROLLBAR)
 
             # List items.
             checkbox_size = viz.app.font_size + viz.app.spacing * 2
@@ -198,11 +198,11 @@ class LayerWidget:
             # End list.
             if len(layers) == 0:
                 imgui.text_colored('No layers found', *dim_color)
-            imgui.end_child()
+            imgui_utils.end_child()
             imgui.pop_style_color(4)
             imgui.pop_style_var(1)
             imgui.same_line()
-            imgui.begin_child('##adjust', width=-1, height=height, border=True)
+            imgui_utils.begin_child(self, '##adjust', width=-1, height=height, border=True)
             tab_width = imgui.get_content_region_available_width() // 2 - viz.app.spacing
             if imgui_utils.button("Activations",
                                   width=tab_width, enabled=self.tab):
@@ -236,7 +236,7 @@ class LayerWidget:
                     #     self.adjust_widget(layers)
             else:
                 self.adjust_noise()
-            imgui.end_child()
+            imgui_utils.end_child()
 
             if self.cur_layer is not None:
                 self.ratios[self.cur_layer] = ratio

--- a/widgets/osc_menu.py
+++ b/widgets/osc_menu.py
@@ -145,8 +145,15 @@ class OscMenu:
     @imgui_utils.scoped_by_object_id
     def __call__(self):
         viz = self.viz
+        # Everything here lives in the menu bar, so the child never scrolls and
+        # NoScrollWithMouse is stated outright rather than left to
+        # imgui_utils.begin_child: window padding overflows the 1.5-line height
+        # by a few pixels, which reads as "scrollable" and would keep the strip
+        # swallowing the wheel. Adding NoScrollbar here would block the
+        # pass-through imgui 1.65 grants in exchange for NoScrollWithMouse.
         imgui.begin_child(self.label, viz.pane_w, viz.app.font_size*1.5,
-                          flags=imgui.WINDOW_NO_TITLE_BAR | imgui.WINDOW_NO_RESIZE | imgui.WINDOW_NO_MOVE | imgui.WINDOW_MENU_BAR)
+                          flags=imgui.WINDOW_NO_TITLE_BAR | imgui.WINDOW_NO_RESIZE | imgui.WINDOW_NO_MOVE
+                          | imgui.WINDOW_MENU_BAR | imgui.WINDOW_NO_SCROLL_WITH_MOUSE)
         if imgui.begin_menu_bar():
             imgui.text("OSC Menu |")
             for key in self.funcs.keys():


### PR DESCRIPTION
## Summary

Fixes two long-standing mouse wheel problems in the perform pane: scrolling was far too fast (on macOS a single wheel notch moved the pane ~384 px, and a two-finger swipe moved it nearly 13x the finger travel), and the wheel did nothing at all when the cursor sat on an OSC menu strip or a Layer Transformations panel. Both date back to the initial import and are independent, so they are two separate commits.

**Scroll speed.** The scale came in with the NVIDIA visualizer as `_cur_font_size / 10` and was never revisited. It double-counts the display scale — imgui already scrolls by `mouse_wheel * 5 * font_size`, which is constant in DPI-independent units — and it assumes GLFW hands out one unit per wheel notch. That holds on Windows and X11 (`HIWORD(wParam) / WHEEL_DELTA`) but not on macOS, which reports the OS line rate (3 per notch) or, on precise devices, points/10. Replaced with a per-platform constant that lands a notch on ~60 units on both.

**Dead zones.** `imgui==1.4.1` bundles Dear ImGui 1.65, which only passes the wheel from a child up to its parent when the child sets `NoScrollWithMouse` and not `NoScrollbar`. A child that simply has nothing to scroll swallows the event instead, so every child covering the pane becomes a dead band — the OSC menu strips alone put eight full-width ones across it. Upstream fixed this in 1.72 by also forwarding when `ScrollMax` is 0, which our pin predates. Added `imgui_utils.begin_child` / `end_child` wrappers that reproduce that rule from the previous frame's `ScrollMax`, and routed the layer panels through them. The OSC menu strips state `NoScrollWithMouse` outright instead: their window padding overflows the 1.5-line height by ~7 px, so the wrappers would read them as scrollable and leave them swallowing the wheel.

No dependency change — both fixes work against the current pin.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Other (docs, refactor, chore, ci, etc.)

## How was this tested?

**macOS 26 (Apple silicon, retina) — verified manually.** `uv run main.py`, perform pane, both a wheel mouse and the trackpad. Scrolling now feels close to native; the OSC menu strips and the Layer Transformations panels all pass the wheel through to the pane, and the layer list still scrolls itself once a model is loaded and it has content to scroll.

**Measured, not estimated.** A GLFW probe captured the real deltas this platform delivers, which is what the new constants are derived from:

| device | raw `y_offset` | before | after |
|---|---|---|---|
| wheel, one notch | exactly 3.000 | 384 px | ~60 px |
| trackpad, ~2 pt of finger travel | 0.100–0.400 | 25.6 px | ~4 px |

A headless imgui harness reproduced the dead zone and confirmed the fix, with the cursor parked on an OSC strip and only the flag differing:

```
without NoScrollWithMouse (old): pane scroll_y =  0.00  DEAD ZONE
with    NoScrollWithMouse (new): pane scroll_y = 48.75  scrolls
```

**Automated.** `tests/test_imgui_child_scroll.py` adds 7 tests over the wrapper: the flag logic, the stale-frame transitions in both directions, the `NoScrollbar` strip that 1.65 requires before it will climb, label collisions between the two `LayerWidget` classes, and nested unwinding. Full suite: 22 passed.

### Still to verify — Windows and Linux

Neither platform has been exercised. Both are affected by this PR and the change is per-platform, so the non-darwin constant (`0.75`) is reasoned from GLFW's source rather than measured on hardware:

- **Windows** — confirm a wheel notch scrolls a sensible distance, and that it no longer changes with display scale. The DPI double-count meant the same gesture scrolled 1.6x further at 100% and 2.4x at 150%; that coupling is gone, but only the macOS half has been checked on real hardware.
- **Linux (X11 and Wayland/XWayland)** — same wheel check. XWayland HiDPI has its own scaling correction in `_GlfwRenderer.process_inputs`, which is worth a look at a non-100% scale.
- **Both** — cursor on an OSC menu strip and on the Layer Transformations panels (empty and populated) should scroll the pane.

If a notch feels wrong on either, the fix is the one constant in `utils/gui_utils/imgui_window.py`.

No screenshot attached: the change is to scroll behavior, which a still frame cannot show.

## Checklist

- [x] PR title follows Conventional Commits without a scope (`<type>: <subject>`)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Documentation in `docs/` or `README.md` is updated if user-visible behavior changed — n/a, no doc covers scrolling
- [x] If this PR adds new runtime files, they are included in `release.py` — n/a, no new runtime files
- [ ] Screenshots or a short clip are attached for UI changes — n/a, behavioral not visual

Generated with AI assistance
