### PR TITLE
Stop offering crash reports after non-crash exits

### DIFF
--- a/modules/autolume_live.py
+++ b/modules/autolume_live.py
@@ -152,6 +152,10 @@ class Autolume(imgui_window.ImguiWindow):
         self._adjust_font_size()
         self.skip_frame()  # Layout may change after first frame.
 
+        # Windows announces a shutdown to the window, so this can only be
+        # hooked once there is one.
+        crash_report.install_session_end_hook(self.native_handle())
+
     @classmethod
     def _clamp_ui_font_size(cls, size):
         return int(min(max(size, cls.MIN_UI_FONT_SIZE), cls.MAX_UI_FONT_SIZE))
@@ -179,6 +183,8 @@ class Autolume(imgui_window.ImguiWindow):
             self.skip_frame() # Layout changed.
 
     def close(self):
+        crash_report.remove_session_end_hook()
+
         if self.data_preprocessing is not None:
             self.data_preprocessing.cleanup()
             self.data_preprocessing = None

--- a/tests/test_crash_marker.py
+++ b/tests/test_crash_marker.py
@@ -1,0 +1,288 @@
+import json
+import os
+
+import pytest
+
+from utils import crash_report
+
+
+@pytest.fixture
+def marker(tmp_path, monkeypatch):
+    """Point the markers at a temp dir and reset the module's run state."""
+    runs = tmp_path / "logs" / "runs"
+    runs.mkdir(parents=True)
+    monkeypatch.setattr(crash_report.user_data, "data_path",
+                        lambda *parts: tmp_path.joinpath(*parts))
+    monkeypatch.setattr(crash_report.user_data, "ensure_data_path",
+                        lambda *parts: tmp_path.joinpath(*parts))
+    monkeypatch.setattr(crash_report, "_marker_base", None)
+    monkeypatch.setattr(crash_report, "_exit_reason", None)
+    monkeypatch.setattr(crash_report, "_exit_reason_at", 0.0)
+    crash_report._heartbeat_stop.clear()
+    yield runs / ("%d.json" % os.getpid())
+    crash_report._heartbeat_stop.set()
+    crash_report._marker_base = None
+
+
+@pytest.fixture
+def shutdown_clock(monkeypatch):
+    """Replace the OS shutdown clock with a value the test controls."""
+    def install(value):
+        monkeypatch.setattr(crash_report, "_last_os_shutdown_time", lambda: value)
+    return install
+
+
+def test_reads_back_what_it_wrote(marker):
+    crash_report.mark_running()
+    info = crash_report._read_marker()
+    assert info["version"] == crash_report.MARKER_VERSION
+    assert info["exit"] is None
+    assert info["heartbeat"] >= info["started"]
+    assert info["crashes_size"] == 0
+
+
+def test_legacy_pid_marker_is_not_mistaken_for_session_data(marker):
+    # json.loads("12345") succeeds and yields an int, so an isinstance check is
+    # the only thing standing between the old format and an attribute error.
+    marker.write_text("12345", encoding="utf-8")
+    assert crash_report._read_marker() == {"version": 1}
+
+
+@pytest.mark.parametrize("content", ["", "{not json", "[1, 2]", "null"])
+def test_unreadable_marker_reads_as_legacy(marker, content):
+    marker.write_text(content, encoding="utf-8")
+    assert crash_report._read_marker() == {"version": 1}
+
+
+def test_no_marker_reads_as_none(marker):
+    assert crash_report._read_marker() is None
+
+
+def test_clean_exit_removes_the_marker(marker):
+    crash_report.mark_running()
+    assert marker.exists()
+    crash_report.mark_clean_exit()
+    assert not marker.exists()
+
+
+def test_a_late_heartbeat_cannot_resurrect_a_cleared_marker(marker):
+    # A tick already past its wait and blocked on the lock still runs after
+    # mark_clean_exit; if it wrote, every later launch would show a phantom
+    # crash popup.
+    crash_report.mark_running()
+    crash_report.mark_clean_exit()
+    crash_report._write_marker()
+    assert not marker.exists()
+
+
+def test_exit_reason_is_stamped_into_the_marker(marker):
+    crash_report.mark_running()
+    crash_report._set_exit_reason("shutdown")
+    assert crash_report._read_marker()["exit"] == "shutdown"
+    crash_report._set_exit_reason(None)
+    assert crash_report._read_marker()["exit"] is None
+
+
+def test_a_session_end_that_never_happened_stops_counting(marker, monkeypatch):
+    # A shutdown request that is abandoned without the cancelling WM_ENDSESSION
+    # would otherwise leave the stamp on for the rest of the run, suppressing
+    # any real crash after it.
+    crash_report.mark_running()
+    crash_report._set_exit_reason("shutdown")
+    monkeypatch.setattr(crash_report, "_exit_reason_at",
+                        crash_report._exit_reason_at - crash_report.SESSION_END_GRACE - 1)
+    crash_report._heartbeat_tick()
+    assert crash_report._read_marker()["exit"] is None
+
+
+def test_a_fresh_session_end_survives_a_heartbeat(marker):
+    crash_report.mark_running()
+    crash_report._set_exit_reason("shutdown")
+    crash_report._heartbeat_tick()
+    assert crash_report._read_marker()["exit"] == "shutdown"
+
+
+def test_marker_write_is_atomic(marker):
+    crash_report.mark_running()
+    crash_report._write_marker()
+    # A reader must never catch a half-written file, so the payload only ever
+    # appears under the final name.
+    assert json.loads(marker.read_text(encoding="utf-8"))["version"] == 2
+
+
+class TestCrashEvidence:
+    """A death only becomes a report when the crash handler left a trace."""
+
+    def test_a_grown_crash_log_is_evidence(self, marker):
+        crash_report.mark_running()
+        info = crash_report._read_marker()
+        (marker.parent.parent / "crashes.log").write_text(
+            "Windows fatal exception: access violation", encoding="utf-8")
+        assert crash_report._crash_evidence(info)
+
+    def test_an_untouched_crash_log_is_not_evidence(self, marker):
+        crash_report.mark_running()
+        assert not crash_report._crash_evidence(crash_report._read_marker())
+
+    def test_process_start_banners_are_not_evidence(self, marker):
+        # Normal runs append banners for themselves and their workers, so the
+        # log growing is business as usual, not a fault.
+        crash_report.mark_running()
+        info = crash_report._read_marker()
+        (marker.parent.parent / "crashes.log").write_text(
+            "--- pid 123 (MainProcess) started ---\n"
+            "--- pid 456 (renderer) started ---\n", encoding="utf-8")
+        assert not crash_report._crash_evidence(info)
+
+    def test_a_fault_after_banners_is_evidence(self, marker):
+        crash_report.mark_running()
+        info = crash_report._read_marker()
+        (marker.parent.parent / "crashes.log").write_text(
+            "--- pid 123 (renderer) started ---\n"
+            "Windows fatal exception: access violation\n", encoding="utf-8")
+        assert crash_report._crash_evidence(info)
+
+    def test_a_truncated_crash_log_is_not_evidence(self, marker):
+        (marker.parent.parent / "crashes.log").write_text(
+            "old fatal content from before this run", encoding="utf-8")
+        crash_report.mark_running()
+        info = crash_report._read_marker()
+        (marker.parent.parent / "crashes.log").write_text(
+            "short", encoding="utf-8")
+        assert not crash_report._crash_evidence(info)
+
+    def test_a_marker_without_a_size_is_not_evidence(self, marker):
+        # Markers from builds that predate the evidence gate: at worst one
+        # leftover crash goes unreported once, at the upgrade.
+        assert not crash_report._crash_evidence({"version": 1})
+
+
+class TestShutdownClassification:
+    """A shutdown is only recognised on positive evidence of one."""
+
+    def test_a_signalled_session_end_is_a_shutdown(self, shutdown_clock):
+        shutdown_clock(None)
+        assert crash_report._shutdown_evidence({"exit": "shutdown"})
+
+    def test_dying_just_before_a_new_shutdown_is_a_shutdown(self, shutdown_clock):
+        shutdown_clock(2_000_000.0)
+        assert crash_report._shutdown_evidence(
+            {"heartbeat": 1_999_988.0, "os_shutdown": 1_000_000.0})
+
+    def test_dying_long_before_the_shutdown_is_not_a_shutdown(self, shutdown_clock):
+        shutdown_clock(2_000_000.0)
+        assert crash_report._shutdown_evidence(
+            {"heartbeat": 1_990_000.0, "os_shutdown": 1_000_000.0}) is None
+
+    def test_an_unchanged_shutdown_clock_is_not_a_shutdown(self, shutdown_clock):
+        # Nothing has shut down since this run started, so whatever ended it,
+        # the machine going down was not it.
+        shutdown_clock(2_000_000.0)
+        assert crash_report._shutdown_evidence(
+            {"heartbeat": 2_000_500.0, "os_shutdown": 2_000_000.0}) is None
+
+    def test_no_shutdown_clock_is_not_a_shutdown(self, shutdown_clock):
+        # macOS and Linux have no cheap equivalent, and they get a signal
+        # instead; the crash-evidence gate decides what happens next.
+        shutdown_clock(None)
+        assert crash_report._shutdown_evidence(
+            {"heartbeat": 2_000_000.0, "os_shutdown": None}) is None
+
+    def test_a_marker_without_a_heartbeat_is_not_a_shutdown(self, shutdown_clock):
+        shutdown_clock(2_000_000.0)
+        assert crash_report._shutdown_evidence({"version": 1}) is None
+
+
+def test_shutdown_marker_is_dropped_without_a_pending_report(
+        marker, shutdown_clock, monkeypatch):
+    shutdown_clock(None)
+    crash_report.mark_running()
+    crash_report._set_exit_reason("shutdown")
+    crash_report._marker_base = None  # the run is over; the file remains
+    monkeypatch.setattr(crash_report, "_still_running", lambda m: False)
+
+    assert crash_report.check_unclean_exit() is None
+    assert crash_report.pending_unclean_report() is None
+    # Dropped here rather than downstream, so "always send" mode has nothing
+    # left to upload silently.
+    assert not marker.exists()
+
+
+def test_a_native_fault_still_produces_a_pending_report(
+        marker, shutdown_clock, monkeypatch):
+    shutdown_clock(None)
+    crash_report.mark_running()
+    (marker.parent.parent / "crashes.log").write_text(
+        "Windows fatal exception: access violation", encoding="utf-8")
+    crash_report._marker_base = None
+    monkeypatch.setattr(crash_report, "_still_running", lambda m: False)
+
+    assert crash_report.check_unclean_exit() is not None
+    assert crash_report.pending_unclean_report() is not None
+    assert not marker.exists()
+
+
+def test_a_kill_without_crash_evidence_is_dropped(
+        marker, shutdown_clock, monkeypatch):
+    # Task Manager, power loss, a frozen app put down by the user: no trace
+    # in the crash log, no report.
+    shutdown_clock(None)
+    crash_report.mark_running()
+    crash_report._marker_base = None
+    monkeypatch.setattr(crash_report, "_still_running", lambda m: False)
+
+    assert crash_report.check_unclean_exit() is None
+    assert crash_report.pending_unclean_report() is None
+    assert not marker.exists()
+
+
+class TestLiveness:
+    """A marker is only "alive" when pid and creation time both match."""
+
+    def test_our_own_marker_reads_as_alive(self, marker):
+        crash_report.mark_running()
+        assert crash_report._still_running(crash_report._read_marker())
+
+    def test_a_recycled_pid_does_not_look_alive(self):
+        # Windows reuses pids; the creation time is what tells the crashed
+        # run's pid from the unrelated process now wearing it.
+        assert not crash_report._still_running(
+            {"pid": os.getpid(), "create": 123.0})
+
+    def test_a_marker_without_a_create_time_counts_as_dead(self):
+        assert not crash_report._still_running({"pid": os.getpid()})
+
+    def test_a_dead_pid_counts_as_dead(self):
+        # A pid beyond the OS's range can never be running.
+        assert not crash_report._still_running(
+            {"pid": 2 ** 31 - 1, "create": 123.0})
+
+
+def test_a_live_instances_marker_is_left_alone(marker, shutdown_clock):
+    shutdown_clock(None)
+    crash_report.mark_running()  # a real marker for a really-running process
+    crash_report._heartbeat_stop.set()
+
+    assert crash_report.check_unclean_exit() is None
+    assert crash_report.pending_unclean_report() is None
+    assert marker.exists()
+
+
+def test_legacy_shared_marker_is_swept_without_a_report(marker, shutdown_clock):
+    # Pre-upgrade markers carry no crash-log size, so they cannot clear the
+    # evidence gate; the file still has to go or it would be rescanned forever.
+    shutdown_clock(None)
+    legacy = marker.parent.parent / "last_run"
+    legacy.write_text("12345", encoding="utf-8")
+
+    assert crash_report.check_unclean_exit() is None
+    assert not legacy.exists()
+
+
+def test_stale_tmp_files_are_swept(marker, shutdown_clock):
+    shutdown_clock(None)
+    stale = marker.parent / "999.json.tmp"
+    stale.write_text("{", encoding="utf-8")
+
+    crash_report.check_unclean_exit()
+    assert not stale.exists()

--- a/tests/test_crash_marker.py
+++ b/tests/test_crash_marker.py
@@ -8,12 +8,14 @@ from utils import crash_report
 
 @pytest.fixture
 def marker(tmp_path, monkeypatch):
-    """Point the markers at a temp dir and reset the module's run state."""
-    runs = tmp_path / "logs" / "runs"
+    """Point markers at a temp config dir, logs at a temp data root, and
+    reset the module's run state."""
+    runs = tmp_path / "config" / "runs"
     runs.mkdir(parents=True)
+    (tmp_path / "logs").mkdir()
+    monkeypatch.setattr(crash_report.user_data, "config_dir",
+                        lambda: tmp_path / "config")
     monkeypatch.setattr(crash_report.user_data, "data_path",
-                        lambda *parts: tmp_path.joinpath(*parts))
-    monkeypatch.setattr(crash_report.user_data, "ensure_data_path",
                         lambda *parts: tmp_path.joinpath(*parts))
     monkeypatch.setattr(crash_report, "_marker_base", None)
     monkeypatch.setattr(crash_report, "_exit_reason", None)
@@ -32,13 +34,23 @@ def shutdown_clock(monkeypatch):
     return install
 
 
-def test_reads_back_what_it_wrote(marker):
+def test_reads_back_what_it_wrote(marker, tmp_path):
     crash_report.mark_running()
     info = crash_report._read_marker()
     assert info["version"] == crash_report.MARKER_VERSION
     assert info["exit"] is None
     assert info["heartbeat"] >= info["started"]
     assert info["crashes_size"] == 0
+    assert info["logs"] == str(tmp_path / "logs")
+
+
+def test_marker_lives_in_the_config_dir_not_the_data_root(marker, tmp_path):
+    # The data root may be a slow, removable or fragile mount; per-run state
+    # written every heartbeat and scanned at startup must stay local.
+    crash_report.mark_running()
+    assert marker.exists()
+    assert marker.is_relative_to(tmp_path / "config")
+    assert not marker.is_relative_to(tmp_path / "logs")
 
 
 def test_legacy_pid_marker_is_not_mistaken_for_session_data(marker):
@@ -113,10 +125,10 @@ def test_marker_write_is_atomic(marker):
 class TestCrashEvidence:
     """A death only becomes a report when the crash handler left a trace."""
 
-    def test_a_grown_crash_log_is_evidence(self, marker):
+    def test_a_grown_crash_log_is_evidence(self, marker, tmp_path):
         crash_report.mark_running()
         info = crash_report._read_marker()
-        (marker.parent.parent / "crashes.log").write_text(
+        (tmp_path / "logs" / "crashes.log").write_text(
             "Windows fatal exception: access violation", encoding="utf-8")
         assert crash_report._crash_evidence(info)
 
@@ -124,30 +136,30 @@ class TestCrashEvidence:
         crash_report.mark_running()
         assert not crash_report._crash_evidence(crash_report._read_marker())
 
-    def test_process_start_banners_are_not_evidence(self, marker):
+    def test_process_start_banners_are_not_evidence(self, marker, tmp_path):
         # Normal runs append banners for themselves and their workers, so the
         # log growing is business as usual, not a fault.
         crash_report.mark_running()
         info = crash_report._read_marker()
-        (marker.parent.parent / "crashes.log").write_text(
+        (tmp_path / "logs" / "crashes.log").write_text(
             "--- pid 123 (MainProcess) started ---\n"
             "--- pid 456 (renderer) started ---\n", encoding="utf-8")
         assert not crash_report._crash_evidence(info)
 
-    def test_a_fault_after_banners_is_evidence(self, marker):
+    def test_a_fault_after_banners_is_evidence(self, marker, tmp_path):
         crash_report.mark_running()
         info = crash_report._read_marker()
-        (marker.parent.parent / "crashes.log").write_text(
+        (tmp_path / "logs" / "crashes.log").write_text(
             "--- pid 123 (renderer) started ---\n"
             "Windows fatal exception: access violation\n", encoding="utf-8")
         assert crash_report._crash_evidence(info)
 
-    def test_a_truncated_crash_log_is_not_evidence(self, marker):
-        (marker.parent.parent / "crashes.log").write_text(
+    def test_a_truncated_crash_log_is_not_evidence(self, marker, tmp_path):
+        (tmp_path / "logs" / "crashes.log").write_text(
             "old fatal content from before this run", encoding="utf-8")
         crash_report.mark_running()
         info = crash_report._read_marker()
-        (marker.parent.parent / "crashes.log").write_text(
+        (tmp_path / "logs" / "crashes.log").write_text(
             "short", encoding="utf-8")
         assert not crash_report._crash_evidence(info)
 
@@ -155,6 +167,21 @@ class TestCrashEvidence:
         # Markers from builds that predate the evidence gate: at worst one
         # leftover crash goes unreported once, at the upgrade.
         assert not crash_report._crash_evidence({"version": 1})
+
+    def test_evidence_follows_the_recorded_logs_dir(self, marker, tmp_path,
+                                                    monkeypatch):
+        # The marker outlives the run that wrote it; if the data root pref
+        # changes in between, evidence must be read from where that run
+        # actually logged, not from the new root.
+        crash_report.mark_running()
+        info = crash_report._read_marker()
+        (tmp_path / "logs" / "crashes.log").write_text(
+            "Fatal Python error: Segmentation fault", encoding="utf-8")
+        moved = tmp_path / "elsewhere"
+        (moved / "logs").mkdir(parents=True)
+        monkeypatch.setattr(crash_report.user_data, "data_path",
+                            lambda *parts: moved.joinpath(*parts))
+        assert crash_report._crash_evidence(info)
 
 
 class TestShutdownClassification:
@@ -209,10 +236,10 @@ def test_shutdown_marker_is_dropped_without_a_pending_report(
 
 
 def test_a_native_fault_still_produces_a_pending_report(
-        marker, shutdown_clock, monkeypatch):
+        marker, shutdown_clock, monkeypatch, tmp_path):
     shutdown_clock(None)
     crash_report.mark_running()
-    (marker.parent.parent / "crashes.log").write_text(
+    (tmp_path / "logs" / "crashes.log").write_text(
         "Windows fatal exception: access violation", encoding="utf-8")
     crash_report._marker_base = None
     monkeypatch.setattr(crash_report, "_still_running", lambda m: False)
@@ -268,11 +295,12 @@ def test_a_live_instances_marker_is_left_alone(marker, shutdown_clock):
     assert marker.exists()
 
 
-def test_legacy_shared_marker_is_swept_without_a_report(marker, shutdown_clock):
+def test_legacy_shared_marker_is_swept_without_a_report(
+        marker, shutdown_clock, tmp_path):
     # Pre-upgrade markers carry no crash-log size, so they cannot clear the
     # evidence gate; the file still has to go or it would be rescanned forever.
     shutdown_clock(None)
-    legacy = marker.parent.parent / "last_run"
+    legacy = tmp_path / "logs" / "last_run"
     legacy.write_text("12345", encoding="utf-8")
 
     assert crash_report.check_unclean_exit() is None

--- a/utils/crash_report.py
+++ b/utils/crash_report.py
@@ -4,10 +4,21 @@ Two catch paths feed this module:
 - Path A: ``main.py``'s top-level ``except BaseException`` calls
   :func:`handle_fatal_exception`, which shows a native OS dialog (imgui is
   dead at that point) and uploads on consent.
-- Path B: a ``logs/last_run`` marker left behind by a hard native crash
-  (segfault, driver death) is detected on the next launch by
+- Path B: a per-process marker under ``logs/runs`` left behind by a hard
+  native crash (segfault, driver death) is detected on the next launch by
   :func:`process_startup`; the imgui popup in ``modules/autolume_live``
   offers to send the previous run's logs.
+
+Many things besides a crash can kill the process uncleanly — an OS shutdown,
+a closed terminal, Task Manager — so path B only reports on positive crash
+evidence: faulthandler (armed in ``utils/app_logging``) appends to
+``logs/crashes.log`` at the moment of a native fault, and a dead run's marker
+turns into a report only when a fault dump landed there during the run. Session
+ends are additionally recognised on their own (a session-end hook stamps the
+marker, a heartbeat correlates the death with the OS shutdown clock) so they
+can be logged as such; every other evidence-free death is dropped with a log
+line, the same way engines like Unreal only report when their crash handler
+actually fired.
 
 Reports go to a Google Apps Script endpoint as JSON (metadata + base64
 zip). The endpoint URL and token come from ``AUTOLUME_CRASH_REPORT_URL``
@@ -25,10 +36,13 @@ import json
 import logging
 import os
 import platform
+import signal
+import struct
 import subprocess
 import sys
 import tempfile
 import threading
+import time
 import traceback
 import urllib.request
 import uuid
@@ -47,9 +61,26 @@ LOG_TAIL_BYTES = 500_000
 CRASHES_TAIL_BYTES = 1_000_000
 MAX_PAYLOAD_BYTES = 10_000_000
 
+MARKER_VERSION = 2
+HEARTBEAT_SECONDS = 15
+# How far from the last heartbeat the OS may record a shutdown and still
+# explain the death: clock jitter on the early side, the time the rest of the
+# session takes to tear down on the late side. A run that stopped breathing
+# well before the machine went down died of something else.
+SHUTDOWN_MATCH_BEFORE = 60
+SHUTDOWN_MATCH_AFTER = 300
+# How long a recorded session end stays believable while the run carries on.
+SESSION_END_GRACE = 120
+
 _endpoint_override = None
 _endpoint_cache = None
 _pending = None
+
+_marker_lock = threading.Lock()
+_marker_base = None
+_exit_reason = None
+_exit_reason_at = 0.0
+_heartbeat_stop = threading.Event()
 
 
 def _parse_env(path):
@@ -263,29 +294,374 @@ def send_report(zip_path, meta):
         return False
 
 
+def _runs_dir():
+    return user_data.data_path("logs", "runs")
+
+
 def _marker_path():
-    return user_data.data_path("logs", "last_run")
+    """This run's own marker. One file per process, so concurrent instances
+    never overwrite each other's heartbeat."""
+    return _runs_dir() / ("%d.json" % os.getpid())
+
+
+def _own_create_time():
+    """This process's OS-assigned start time, or None if psutil is broken."""
+    try:
+        import psutil
+        return psutil.Process().create_time()
+    except Exception:
+        return None
+
+
+def _still_running(marker):
+    """True only when the marker's process is verifiably still alive: same
+    pid *and* same creation time, so a recycled pid cannot make a crashed run
+    look alive. Anything unverifiable counts as dead and gets classified."""
+    pid = marker.get("pid")
+    create = marker.get("create")
+    if not isinstance(pid, int) or not isinstance(create, (int, float)):
+        return False
+    try:
+        import psutil
+        return abs(psutil.Process(pid).create_time() - create) < 1.0
+    except Exception:
+        return False
+
+
+def _write_marker():
+    """Rewrite the marker with a fresh heartbeat. Atomic, so a kill mid-write
+    cannot leave a truncated file behind. No-op once the marker is cleared."""
+    try:
+        with _marker_lock:
+            if _marker_base is None:
+                return
+            payload = dict(_marker_base, heartbeat=time.time(), exit=_exit_reason)
+            path = _marker_path()
+            tmp = path.with_name(path.name + ".tmp")
+            tmp.write_text(json.dumps(payload), encoding="utf-8")
+            os.replace(tmp, path)
+    except Exception:
+        pass
+
+
+def _read_marker(path=None):
+    """Marker contents as a dict, or None if there is no marker.
+
+    Markers written before the heartbeat existed hold a bare pid; report those
+    as version 1 so they classify as a crash, exactly as they used to.
+    """
+    try:
+        data = json.loads((path or _marker_path()).read_text(encoding="utf-8"))
+    except OSError:
+        return None
+    except ValueError:
+        return {"version": 1}
+    return data if isinstance(data, dict) else {"version": 1}
+
+
+def _heartbeat_tick():
+    if _exit_reason and time.time() - _exit_reason_at > SESSION_END_GRACE:
+        # Windows kills what is left of a session within seconds, so still
+        # running this long after being asked to go means the shutdown was
+        # called off. Drop the stamp rather than let it suppress a real crash
+        # later in the run.
+        _set_exit_reason(None)
+    else:
+        _write_marker()
+
+
+def _heartbeat_loop():
+    while not _heartbeat_stop.wait(HEARTBEAT_SECONDS):
+        _heartbeat_tick()
 
 
 def mark_running():
-    """Arm the unclean-exit marker for this run."""
+    """Arm the unclean-exit marker for this run and start its heartbeat."""
+    global _marker_base
     try:
-        path = user_data.ensure_data_path("logs") / "last_run"
-        path.write_text(str(os.getpid()), encoding="utf-8")
+        user_data.ensure_data_path("logs", "runs")
+        # Recording the shutdown clock as it stands now is what lets the next
+        # launch tell a *new* shutdown from the one before this run started.
+        base = {"version": MARKER_VERSION, "pid": os.getpid(),
+                "create": _own_create_time(),
+                "started": time.time(),
+                "os_shutdown": _last_os_shutdown_time(),
+                "crashes_size": _crashes_log_size()}
+        with _marker_lock:
+            _marker_base = base
+        _write_marker()
+        _heartbeat_stop.clear()
+        threading.Thread(target=_heartbeat_loop, daemon=True).start()
     except Exception:
         pass
 
 
 def mark_clean_exit():
     """Clear the marker: this run ended cleanly or its crash was handled."""
+    global _marker_base
     try:
-        _marker_path().unlink(missing_ok=True)
+        _heartbeat_stop.set()
+        with _marker_lock:
+            _marker_base = None
+            _marker_path().unlink(missing_ok=True)
     except Exception:
         pass
 
 
+def _set_exit_reason(reason):
+    """Stamp why this run is ending into the marker. Called from a WndProc, a
+    console control handler and a signal handler, so it must never raise."""
+    global _exit_reason, _exit_reason_at
+    try:
+        _exit_reason = reason
+        _exit_reason_at = time.time()
+        _write_marker()
+    except Exception:
+        pass
+
+
+def _last_os_shutdown_time():
+    """When the OS last finished shutting down, or None if unknown.
+
+    Windows only: it is the one platform where the shipped build is windowed,
+    gets no SIGTERM, and can be killed at session end before the message pump
+    has had a chance to run. The value is an 8-byte FILETIME the session
+    manager writes at the end of every clean shutdown, readable unelevated.
+    """
+    if sys.platform != "win32":
+        return None
+    try:
+        import winreg
+        with winreg.OpenKey(
+                winreg.HKEY_LOCAL_MACHINE,
+                r"SYSTEM\CurrentControlSet\Control\Windows") as key:
+            raw, kind = winreg.QueryValueEx(key, "ShutdownTime")
+        if kind != winreg.REG_BINARY or len(raw) != 8:
+            return None
+        # FILETIME: 100ns ticks since 1601-01-01.
+        return struct.unpack("<Q", raw)[0] / 10_000_000.0 - 11_644_473_600.0
+    except Exception:
+        return None
+
+
+def _crashes_log_size():
+    """Current size of the native crash log, or 0 if there is none."""
+    try:
+        return os.path.getsize(user_data.data_path("logs", "crashes.log"))
+    except OSError:
+        return 0
+
+
+def _crash_evidence(marker):
+    """True when faulthandler dumped a fault while the marker's run was alive.
+
+    The crash log is append-only but not fault-only: every process appends a
+    start banner (see utils/app_logging), and each run spawns workers that do
+    the same, so growth alone proves nothing. What counts is the content
+    faulthandler wrote after the run armed its marker: its dumps always open
+    with "Fatal Python error" or "Windows fatal exception". A kill that
+    leaves no such trace (Task Manager, power loss, a frozen app put down by
+    the user) produces no report: only what the handler caught gets offered,
+    the way engine-style crash reporters behave.
+    """
+    offset = marker.get("crashes_size")
+    if not isinstance(offset, int):
+        return False
+    try:
+        with open(user_data.data_path("logs", "crashes.log"), "rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            if fh.tell() < offset:
+                # Truncated or replaced since the run armed; nothing left in
+                # it can be attributed to the run.
+                return False
+            fh.seek(offset)
+            added = fh.read(4 * 1024 * 1024)
+    except OSError:
+        return False
+    return b"fatal" in added.lower()
+
+
+def _shutdown_evidence(marker):
+    """Why the previous run should be read as an OS shutdown, or None.
+
+    Returning None means "no shutdown was involved": a missing heartbeat, a
+    platform with no shutdown clock, a shutdown that does not line up with
+    the moment the run stopped breathing. :func:`_crash_evidence` then
+    decides whether the death is worth a report.
+    """
+    if marker.get("exit") == "shutdown":
+        return "the session end was signalled"
+    heartbeat = marker.get("heartbeat")
+    if not isinstance(heartbeat, (int, float)):
+        return None
+    shutdown = _last_os_shutdown_time()
+    if shutdown is None or shutdown == marker.get("os_shutdown"):
+        # No shutdown has been recorded since the run started, so whatever
+        # ended it, the machine going down was not it.
+        return None
+    delta = shutdown - heartbeat
+    if -SHUTDOWN_MATCH_BEFORE <= delta <= SHUTDOWN_MATCH_AFTER:
+        return "it was still alive %.0fs before the OS finished shutting down" % delta
+    return None
+
+
+GWLP_WNDPROC = -4
+WM_QUERYENDSESSION = 0x0011
+WM_ENDSESSION = 0x0016
+
+_wndproc_hwnd = None
+_wndproc_old = None
+_wndproc_new = None
+
+
+def _install_windows_wndproc(hwnd):
+    """Subclass the window so WM_QUERYENDSESSION reaches us."""
+    global _wndproc_hwnd, _wndproc_old, _wndproc_new
+    import ctypes
+    from ctypes import wintypes
+
+    user32 = ctypes.windll.user32
+    LRESULT = ctypes.c_ssize_t
+    WPARAM = ctypes.c_size_t
+    LPARAM = ctypes.c_ssize_t
+    WNDPROC = ctypes.WINFUNCTYPE(LRESULT, wintypes.HWND, ctypes.c_uint,
+                                 WPARAM, LPARAM)
+
+    # SetWindowLongW truncates a 64-bit proc pointer, and the Ptr variant is
+    # only exported on 64-bit, where it is the one that must be used.
+    set_long = getattr(user32, "SetWindowLongPtrW", None) or user32.SetWindowLongW
+    set_long.restype = LRESULT
+    set_long.argtypes = [wintypes.HWND, ctypes.c_int, LRESULT]
+    user32.CallWindowProcW.restype = LRESULT
+    user32.CallWindowProcW.argtypes = [LRESULT, wintypes.HWND, ctypes.c_uint,
+                                       WPARAM, LPARAM]
+    user32.DefWindowProcW.restype = LRESULT
+    user32.DefWindowProcW.argtypes = [wintypes.HWND, ctypes.c_uint, WPARAM, LPARAM]
+
+    def dispatch(hwnd_, msg, wparam, lparam):
+        try:
+            if msg == WM_QUERYENDSESSION:
+                _set_exit_reason("shutdown")
+            elif msg == WM_ENDSESSION:
+                # A false wParam means the session end was called off again.
+                _set_exit_reason("shutdown" if wparam else None)
+        except Exception:
+            pass
+        old = _wndproc_old
+        if not old:
+            return user32.DefWindowProcW(hwnd_, msg, wparam, lparam)
+        return user32.CallWindowProcW(old, hwnd_, msg, wparam, lparam)
+
+    # GLFW keeps driving the window, so its proc must stay in the chain, and
+    # the callback object has to outlive this call or the pump lands on freed
+    # memory.
+    _wndproc_new = WNDPROC(dispatch)
+    _wndproc_old = set_long(
+        hwnd, GWLP_WNDPROC, ctypes.cast(_wndproc_new, ctypes.c_void_p).value)
+    _wndproc_hwnd = hwnd
+
+
+def _install_posix_signals():
+    """macOS and Linux announce session end with SIGTERM."""
+    def on_terminate(signum, frame):
+        # Stamp, then die the way the OS expects.
+        _set_exit_reason("shutdown")
+        signal.signal(signum, signal.SIG_DFL)
+        os.kill(os.getpid(), signum)
+
+    for name in ("SIGTERM", "SIGHUP"):
+        sig = getattr(signal, name, None)
+        if sig is not None:
+            try:
+                signal.signal(sig, on_terminate)
+            except (ValueError, OSError):
+                pass
+
+
+_console_handler = None
+
+
+def _install_console_ctrl_handler():
+    """Closing the terminal kills the process with no window message and no
+    signal; the console control event is the only notice Windows gives. Dev
+    runs only in practice: the shipped build is windowed and has no console,
+    so there the handler simply never fires."""
+    global _console_handler
+    import ctypes
+
+    HANDLER = ctypes.WINFUNCTYPE(ctypes.c_int, ctypes.c_uint)
+
+    def on_console_event(event):
+        if event in (2, 5, 6):  # CTRL_CLOSE, CTRL_LOGOFF, CTRL_SHUTDOWN
+            _set_exit_reason("shutdown")
+        return False  # keep Python's own Ctrl+C handling in the chain
+
+    # The callback must outlive the process or the console host calls into
+    # freed memory.
+    _console_handler = HANDLER(on_console_event)
+    ctypes.windll.kernel32.SetConsoleCtrlHandler(_console_handler, True)
+
+
+def install_session_end_hook(window_handle):
+    """Hook the window so a Windows session end is recorded before the kill.
+
+    Needs the window to exist, so it is installed from the app rather than at
+    startup; the gap in between is covered by the heartbeat correlation in
+    :func:`_shutdown_evidence`. ``window_handle`` is an HWND, or None on the
+    platforms that get a signal instead.
+    """
+    try:
+        if sys.platform == "win32" and window_handle:
+            _install_windows_wndproc(window_handle)
+    except Exception:
+        pass
+
+
+def remove_session_end_hook():
+    """Restore the original window proc before the window is destroyed.
+
+    ``_wndproc_new`` is deliberately kept alive: if anything subclassed on top
+    of us it still holds our address, and freeing the thunk would leave the
+    message pump calling into released memory.
+    """
+    global _wndproc_hwnd, _wndproc_old
+    try:
+        if _wndproc_hwnd is not None and _wndproc_old:
+            import ctypes
+            user32 = ctypes.windll.user32
+            set_long = (getattr(user32, "SetWindowLongPtrW", None)
+                        or user32.SetWindowLongW)
+            set_long(_wndproc_hwnd, GWLP_WNDPROC, _wndproc_old)
+    except Exception:
+        pass
+    _wndproc_hwnd = _wndproc_old = None
+
+
+def _dead_markers():
+    """Yield (path, marker) for every marker whose process is gone.
+
+    Includes the single shared marker older versions wrote at logs/last_run,
+    so the first launch after an upgrade still classifies it.
+    """
+    legacy = user_data.data_path("logs", "last_run")
+    paths = [legacy] if legacy.exists() else []
+    try:
+        paths += sorted(_runs_dir().glob("*.json"))
+    except OSError:
+        pass
+    for path in paths:
+        marker = _read_marker(path)
+        if marker is not None and not _still_running(marker):
+            yield path, marker
+
+
 def check_unclean_exit():
-    """Detect a marker left by the previous run and snapshot its log tails.
+    """Classify the markers left by dead runs and snapshot the log tails.
+
+    Markers left by an OS shutdown are dropped here rather than downstream, so
+    that ``always`` mode's silent upload is suppressed along with the popup.
+    Markers whose process is still running belong to a concurrent instance and
+    are left alone.
 
     Must run before :func:`mark_running` and early in startup, so the tails
     predate most of this run's log output. Returns the snapshot (also kept
@@ -293,10 +669,30 @@ def check_unclean_exit():
     """
     global _pending
     try:
-        marker = _marker_path()
-        if not marker.exists():
+        try:
+            for stale in _runs_dir().glob("*.tmp"):  # kills mid-write
+                stale.unlink()
+        except OSError:
+            pass
+        crashed = False
+        for path, marker in _dead_markers():
+            shutdown = _shutdown_evidence(marker)
+            if shutdown is not None:
+                logger.info("Previous run ended with the OS session (%s); "
+                            "not reporting it as a crash", shutdown)
+            elif _crash_evidence(marker):
+                crashed = True
+            else:
+                logger.info("Previous run ended without a trace in the crash "
+                            "log (killed?); not reporting it as a crash")
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                pass
+        if not crashed:
+            _pending = None
             return None
-        log_dir = marker.parent
+        log_dir = user_data.data_path("logs")
         log_tail = _read_tail(log_dir / "autolume.log", LOG_TAIL_BYTES)
         if len(log_tail) < 50_000:
             # Fresh file after midnight rotation: the crashed run's output
@@ -348,7 +744,9 @@ def process_startup():
     """Startup hook: detect an unclean previous exit, then arm the marker.
 
     In always mode the pending report is sent silently; in ask mode it is
-    left for the imgui popup in modules/autolume_live.
+    left for the imgui popup in modules/autolume_live. The session-end hooks
+    that need no window go up here too, so a shutdown during the long import
+    phase is still recorded.
     """
     try:
         # Sweep leftover report zips (uploads are synchronous per run).
@@ -368,6 +766,10 @@ def process_startup():
                 and reporting_available()):
             send_pending_report()
         mark_running()
+        if sys.platform == "win32":
+            _install_console_ctrl_handler()
+        else:
+            _install_posix_signals()
     except Exception:
         pass
 
@@ -507,6 +909,10 @@ def handle_fatal_exception():
     does not prompt again. Never raises.
     """
     try:
+        # The dialog below can sit open for minutes. Freeze the heartbeat at
+        # the moment of the crash so that shutting down while it is up does
+        # not make the next launch read this as an OS shutdown.
+        _heartbeat_stop.set()
         exception_text = "".join(traceback.format_exception(*sys.exc_info()))
         try:
             from utils.app_logging import shutdown_logging

--- a/utils/crash_report.py
+++ b/utils/crash_report.py
@@ -4,10 +4,18 @@ Two catch paths feed this module:
 - Path A: ``main.py``'s top-level ``except BaseException`` calls
   :func:`handle_fatal_exception`, which shows a native OS dialog (imgui is
   dead at that point) and uploads on consent.
-- Path B: a per-process marker under ``logs/runs`` left behind by a hard
-  native crash (segfault, driver death) is detected on the next launch by
-  :func:`process_startup`; the imgui popup in ``modules/autolume_live``
-  offers to send the previous run's logs.
+- Path B: a per-process marker left behind by a hard native crash (segfault,
+  driver death) is detected on the next launch by :func:`process_startup`;
+  the imgui popup in ``modules/autolume_live`` offers to send the previous
+  run's logs.
+
+Markers live under the local config dir (beside ``config.json``), not the
+data root: the data root is user-configurable and may sit on a removable,
+NTFS or network mount, and the marker system writes a heartbeat every few
+seconds and is scanned before the UI exists — startup must never block on a
+slow or wedged mount for it. Each marker records the logs directory its run
+wrote to, so crash evidence is checked against the right ``crashes.log``
+even if the data root pref changes between runs.
 
 Many things besides a crash can kill the process uncleanly — an OS shutdown,
 a closed terminal, Task Manager — so path B only reports on positive crash
@@ -295,7 +303,8 @@ def send_report(zip_path, meta):
 
 
 def _runs_dir():
-    return user_data.data_path("logs", "runs")
+    """Per-run markers, beside config.json — never on the data root mount."""
+    return user_data.config_dir() / "runs"
 
 
 def _marker_path():
@@ -379,12 +388,13 @@ def mark_running():
     """Arm the unclean-exit marker for this run and start its heartbeat."""
     global _marker_base
     try:
-        user_data.ensure_data_path("logs", "runs")
+        _runs_dir().mkdir(parents=True, exist_ok=True)
         # Recording the shutdown clock as it stands now is what lets the next
         # launch tell a *new* shutdown from the one before this run started.
         base = {"version": MARKER_VERSION, "pid": os.getpid(),
                 "create": _own_create_time(),
                 "started": time.time(),
+                "logs": str(user_data.data_path("logs")),
                 "os_shutdown": _last_os_shutdown_time(),
                 "crashes_size": _crashes_log_size()}
         with _marker_lock:
@@ -452,6 +462,15 @@ def _crashes_log_size():
         return 0
 
 
+def _marker_logs_dir(marker):
+    """The logs directory the marker's run wrote to. Falls back to the current
+    data root for markers that predate the recorded path."""
+    logs = marker.get("logs")
+    if isinstance(logs, str) and logs:
+        return Path(logs)
+    return user_data.data_path("logs")
+
+
 def _crash_evidence(marker):
     """True when faulthandler dumped a fault while the marker's run was alive.
 
@@ -468,7 +487,7 @@ def _crash_evidence(marker):
     if not isinstance(offset, int):
         return False
     try:
-        with open(user_data.data_path("logs", "crashes.log"), "rb") as fh:
+        with open(_marker_logs_dir(marker) / "crashes.log", "rb") as fh:
             fh.seek(0, os.SEEK_END)
             if fh.tell() < offset:
                 # Truncated or replaced since the run armed; nothing left in
@@ -674,14 +693,14 @@ def check_unclean_exit():
                 stale.unlink()
         except OSError:
             pass
-        crashed = False
+        crashed_logs = None
         for path, marker in _dead_markers():
             shutdown = _shutdown_evidence(marker)
             if shutdown is not None:
                 logger.info("Previous run ended with the OS session (%s); "
                             "not reporting it as a crash", shutdown)
             elif _crash_evidence(marker):
-                crashed = True
+                crashed_logs = _marker_logs_dir(marker)
             else:
                 logger.info("Previous run ended without a trace in the crash "
                             "log (killed?); not reporting it as a crash")
@@ -689,10 +708,10 @@ def check_unclean_exit():
                 path.unlink(missing_ok=True)
             except OSError:
                 pass
-        if not crashed:
+        if crashed_logs is None:
             _pending = None
             return None
-        log_dir = user_data.data_path("logs")
+        log_dir = crashed_logs
         log_tail = _read_tail(log_dir / "autolume.log", LOG_TAIL_BYTES)
         if len(log_tail) < 50_000:
             # Fresh file after midnight rotation: the crashed run's output

--- a/utils/gui_utils/glfw_window.py
+++ b/utils/gui_utils/glfw_window.py
@@ -80,6 +80,19 @@ class GlfwWindow: # pylint: disable=too-many-public-methods
         except Exception as err: # pylint: disable=broad-except
             logger.warning('Failed to set window icon: %s', err)
 
+    def native_handle(self):
+        # Win32 HWND, for the few things GLFW does not expose. None elsewhere,
+        # and on a GLFW built without the Win32 native access header.
+        if sys.platform != 'win32' or not hasattr(glfw, 'get_win32_window'):
+            return None
+        if self._glfw_window is None:
+            return None
+        try:
+            return glfw.get_win32_window(self._glfw_window)
+        except Exception as err: # pylint: disable=broad-except
+            logger.warning('Failed to get the native window handle: %s', err)
+            return None
+
     def close(self):
         if self._drawing_frame:
             self.end_frame()


### PR DESCRIPTION
Fixes #51

## What changed

Reopen crash reports are now evidence-gated: a dead run only produces a report offer when faulthandler wrote a fault dump to `logs/crashes.log` while that run was alive. Everything else is dropped with a log line.

- **Evidence gate** — each run's marker records the byte offset of `crashes.log` at launch; on the next launch, only content appended after that offset counts, and only if it contains a faulthandler dump (`Windows fatal exception` / `Fatal Python error`). Process start banners from workers don't qualify.
- **Session ends are recognised explicitly** — a WndProc hook stamps the marker on `WM_QUERYENDSESSION`/`WM_ENDSESSION`, a console control handler covers closing the terminal in dev runs, SIGTERM/SIGHUP are stamped on POSIX, and a heartbeat + `ShutdownTime` registry correlation backstops the cases where no message arrives. These are logged as session ends rather than crashes.
- **Per-process markers** — `<config dir>/runs/<pid>.json` (beside `config.json`) instead of the shared `logs/last_run`, with liveness verified via psutil (pid + process creation time, so a recycled pid can't masquerade as a live run). Concurrent instances no longer clobber each other or prompt on launch. Legacy shared markers are swept once on upgrade.
- **Markers live in the config dir, not the data root** — run markers are app-internal state, not user data, and the data root is user-configurable and can sit on a removable, shared, or network mount; the 15s heartbeat writes and the startup marker scan must never depend on it. Each marker records the logs directory its run wrote to, so crash evidence and log tails stay consistent even if the data root changes between runs. Logs themselves stay in the data root — they're user-facing.

Behavior summary:

| How the run ended | On next launch |
|---|---|
| OS shutdown, closed terminal | silent, logged as session end |
| Task Manager kill, power loss, external kill | silent, logged as trace-free |
| Segfault / native fault (torch, GL, driver) | report offered |
| Python exception | crash-time dialog, unchanged |

## Testing

- 59 automated tests (`uv run pytest tests`), covering the marker lifecycle, heartbeat races, shutdown classification, liveness, the evidence gate, and the marker/logs directory split (markers never touch the data root; evidence follows the recorded logs dir across a data-root switch).
- Verified live on Windows: OS shutdown (released build), window close, terminal close (`CTRL_CLOSE_EVENT`), Task Manager kill (`taskkill /F`, with worker banners present in the crash log), a real access-violation segfault (report offered with the fault dump in the tail), and two concurrent instances.
- Verified live on Linux after the marker relocation: the app starts and runs normally.

## Pending

- [x] Manual test on **Linux**: SIGTERM/SIGHUP stamping (session end suppressed), segfault via faulthandler still reported.
- [x] Manual test on **macOS**: same as Linux.
