### PR TITLE
Show a clear error instead of crashing on machines without OpenGL

### DIFF
--- a/main.py
+++ b/main.py
@@ -87,6 +87,8 @@ if __name__ == "__main__":
     from utils import crash_report
     crash_report.process_startup()
 
+    from utils import opengl_support
+
     import logging
     logger = logging.getLogger("autolume")
 
@@ -99,6 +101,13 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         crash_report.mark_clean_exit()
         raise
+    except opengl_support.OpenGLUnsupportedError as err:
+        # Not a crash: tell the user what their machine is missing instead of
+        # offering a crash report.
+        logger.critical("Unsupported graphics environment: %s", err)
+        crash_report.mark_clean_exit()
+        opengl_support.show_unsupported_dialog(str(err))
+        sys.exit(1)
     except BaseException:
         logger.critical("Fatal error", exc_info=True)
         crash_report.handle_fatal_exception()

--- a/tests/test_opengl_support.py
+++ b/tests/test_opengl_support.py
@@ -1,0 +1,66 @@
+import ctypes
+import sys
+import types
+
+import pytest
+
+from utils import opengl_support
+
+
+def test_parse_plain_version():
+    assert opengl_support.parse_gl_version("1.1.0") == (1, 1)
+
+
+def test_parse_vendor_suffix():
+    assert opengl_support.parse_gl_version("4.6.0 NVIDIA 551.86") == (4, 6)
+
+
+def test_parse_unparseable():
+    assert opengl_support.parse_gl_version("") == (0, 0)
+    assert opengl_support.parse_gl_version(None) == (0, 0)
+    assert opengl_support.parse_gl_version("Mesa") == (0, 0)
+
+
+@pytest.fixture
+def gl_stub(monkeypatch):
+    """Install a fake OpenGL.GL so no real context is needed."""
+    def install(version, renderer):
+        stub = types.SimpleNamespace(
+            GL_VERSION="version", GL_RENDERER="renderer",
+            glGetString=lambda name: {"version": version,
+                                      "renderer": renderer}[name])
+        monkeypatch.setitem(sys.modules, "OpenGL.GL", stub)
+    return install
+
+
+def test_software_renderer_raises(gl_stub, caplog):
+    gl_stub(b"1.1.0", b"GDI Generic")
+    with pytest.raises(opengl_support.OpenGLUnsupportedError) as exc:
+        opengl_support.check_context_version()
+    assert "OpenGL compatible GPU" in str(exc.value)
+    assert "GDI Generic" in caplog.text
+
+
+def test_missing_version_string_raises(gl_stub):
+    gl_stub(None, None)
+    with pytest.raises(opengl_support.OpenGLUnsupportedError):
+        opengl_support.check_context_version()
+
+
+def test_capable_context_passes(gl_stub):
+    gl_stub(b"4.6.0 NVIDIA 551.86", b"NVIDIA GeForce RTX 3060")
+    opengl_support.check_context_version()
+
+
+def test_null_pointer_window_raises(monkeypatch):
+    # pyGLFW returns the raw ctypes pointer from glfwCreateWindow: on failure
+    # that is a falsy NULL pointer object, not None (the no-GPU crash on the
+    # winget validation VM).
+    null_window = ctypes.POINTER(ctypes.c_void_p)()
+    assert null_window is not None and not null_window
+    stub = types.SimpleNamespace(
+        GLFWError=RuntimeError,
+        create_window=lambda **kwargs: null_window)
+    monkeypatch.setitem(sys.modules, "glfw", stub)
+    with pytest.raises(opengl_support.OpenGLUnsupportedError):
+        opengl_support.checked_create_window(640, 480, "test")

--- a/utils/gui_utils/glfw_window.py
+++ b/utils/gui_utils/glfw_window.py
@@ -15,6 +15,7 @@ import OpenGL.GL as gl
 import PIL.Image
 from . import gl_utils
 from . import dpi
+from utils import opengl_support
 from utils.resource_paths import resource_path
 
 
@@ -43,7 +44,7 @@ class GlfwWindow: # pylint: disable=too-many-public-methods
         self._captured_frame        = None
 
         # Create window.
-        glfw.init()
+        opengl_support.checked_init()
         glfw.window_hint(glfw.VISIBLE, False)
         # Windows measures windows in physical pixels and keeps their pixel size
         # when dragged across monitors, while the UI font follows the monitor's
@@ -56,10 +57,11 @@ class GlfwWindow: # pylint: disable=too-many-public-methods
         # buggy GLX one) picks it up.
         if _wayland_session():
             glfw.window_hint(glfw.CONTEXT_CREATION_API, glfw.EGL_CONTEXT_API)
-        self._glfw_window = glfw.create_window(width=window_width, height=window_height, title=title, monitor=None, share=None)
+        self._glfw_window = opengl_support.checked_create_window(width=window_width, height=window_height, title=title)
         self._set_window_icon()
         self._attach_glfw_callbacks()
         self.make_context_current()
+        opengl_support.check_context_version()
 
         # Adjust window.
         self.set_vsync(False)

--- a/utils/opengl_support.py
+++ b/utils/opengl_support.py
@@ -1,0 +1,115 @@
+"""Startup check that the machine provides the OpenGL context the UI needs.
+
+Machines without a GPU or its driver (virtual machines, remote desktop
+sessions, fresh installs) either fail to create the GLFW window outright or
+fall back to a software renderer (e.g. Windows' "GDI Generic", OpenGL 1.1)
+that cannot run the imgui backend's GLSL 3.30 shaders. Both used to surface
+as an access violation deep inside the GUI stack and trigger the crash-report
+dialog. GlfwWindow routes window creation through the checked helpers below,
+which raise OpenGLUnsupportedError with a user-readable message instead;
+main.py catches it, shows a native dialog via show_unsupported_dialog(), and
+exits cleanly without offering a crash report.
+
+Import-light on purpose (no glfw/OpenGL at module level): main.py imports it
+before the heavy dependency stack loads.
+"""
+
+import logging
+import re
+import subprocess
+import sys
+
+logger = logging.getLogger(__name__)
+
+DIALOG_TITLE = "Autolume"
+
+# The imgui backend compiles GLSL 3.30 shaders on Windows/Linux; macOS runs
+# the fixed-pipeline backend on the 2.1 compatibility context it offers.
+MIN_VERSION = (2, 1) if sys.platform == "darwin" else (3, 3)
+
+_REQUIREMENT = ("Autolume requires an OpenGL compatible GPU and up-to-date "
+                "graphics drivers to run.")
+
+
+class OpenGLUnsupportedError(Exception):
+    """The machine cannot provide the OpenGL context the UI needs."""
+
+
+def checked_init():
+    """glfw.init() that raises OpenGLUnsupportedError on failure."""
+    import glfw
+    try:
+        ok = glfw.init()
+    except glfw.GLFWError as err:
+        raise OpenGLUnsupportedError(_REQUIREMENT) from err
+    if not ok:
+        raise OpenGLUnsupportedError(_REQUIREMENT)
+
+
+def checked_create_window(width, height, title):
+    """glfw.create_window() that raises instead of returning a NULL window.
+
+    Without a capable driver GLFW returns a NULL window (pyGLFW only warns),
+    and the first call that dereferences it dies with an access violation.
+    pyGLFW hands back the raw ctypes pointer, so failure is a falsy NULL
+    pointer object, not None.
+    """
+    import glfw
+    try:
+        window = glfw.create_window(width=width, height=height, title=title,
+                                    monitor=None, share=None)
+    except glfw.GLFWError as err:
+        raise OpenGLUnsupportedError(_REQUIREMENT) from err
+    if not window:
+        raise OpenGLUnsupportedError(_REQUIREMENT)
+    return window
+
+
+def check_context_version():
+    """Verify the current context meets MIN_VERSION; requires a current context.
+
+    Catches software fallbacks where window creation succeeds but the context
+    is far below what the UI needs (e.g. GDI Generic OpenGL 1.1).
+    """
+    import OpenGL.GL as gl
+    version = gl.glGetString(gl.GL_VERSION)
+    renderer = gl.glGetString(gl.GL_RENDERER)
+    version = version.decode("utf-8", "replace") if version else ""
+    renderer = renderer.decode("utf-8", "replace") if renderer else "unknown"
+    if parse_gl_version(version) >= MIN_VERSION:
+        return
+    logger.error("OpenGL context below the %d.%d minimum: version=%r renderer=%r",
+                 *MIN_VERSION, version, renderer)
+    raise OpenGLUnsupportedError(_REQUIREMENT)
+
+
+def parse_gl_version(version_string):
+    """Leading "major.minor" of a GL_VERSION string; (0, 0) if unparseable."""
+    match = re.match(r"(\d+)\.(\d+)", version_string or "")
+    if not match:
+        return (0, 0)
+    return (int(match.group(1)), int(match.group(2)))
+
+
+def show_unsupported_dialog(message):
+    """Best-effort native error dialog; never raises."""
+    print(message, file=sys.stderr)
+    try:
+        if sys.platform == "win32":
+            import ctypes
+            MB_OK, MB_ICONERROR = 0x0, 0x10
+            ctypes.windll.user32.MessageBoxW(
+                None, message, DIALOG_TITLE, MB_OK | MB_ICONERROR)
+        elif sys.platform == "darwin":
+            script = ('display dialog "%s" with title "%s" buttons {"OK"} '
+                      'default button "OK" with icon stop'
+                      % (message.replace('"', "'"), DIALOG_TITLE))
+            subprocess.run(["osascript", "-e", script],
+                           capture_output=True, timeout=300)
+        else:
+            subprocess.run(
+                ["zenity", "--error", "--title", DIALOG_TITLE,
+                 "--text", message],
+                capture_output=True, timeout=300)
+    except Exception:
+        pass


### PR DESCRIPTION
Fixes #53

On machines without a GPU or working driver, `glfw.create_window` fails silently (pyGLFW returns a falsy NULL ctypes pointer and only warns) and the first call to dereference the window died with an access violation, sending users straight to the crash-report dialog.

## Changes

- New `utils/opengl_support.py`: checked wrappers around `glfw.init` / `glfw.create_window` that raise `OpenGLUnsupportedError` on failure, plus a post-context version check that catches software fallbacks (e.g. Windows' GDI Generic OpenGL 1.1, which cannot run the imgui backend's GLSL 3.30 shaders). Import-light so `main.py` can catch the error before the heavy dependency stack loads.
- `GlfwWindow.__init__` routes window creation through the checked helpers.
- `main.py` catches `OpenGLUnsupportedError`, shows a native dialog ("Autolume requires an OpenGL compatible GPU and up-to-date graphics drivers to run."), marks a clean exit so no crash report is offered, and exits with code 1.
- Tests for version parsing, the context version check, and the NULL-pointer window case.

## Testing

- 66 tests pass.
- Verified in Windows Sandbox with `<VGpu>Disable</VGpu>` on the packaged release build: the dialog shows and the app exits cleanly instead of crashing.
- Verified on a real GPU that startup is unaffected.

## Screenshots

### Before

<img width="770" height="379" alt="Screenshot 2026-08-11 090202" src="https://github.com/user-attachments/assets/5c809dcc-258a-470f-965a-26715bd4a701" />

### After

<img width="358" height="174" alt="Screenshot 2026-08-11 at 09 16 23" src="https://github.com/user-attachments/assets/f11aae8d-21e3-4416-abfb-a7fdb3c6062c" />
