### PR TITLE
fix: include noise loop state in looping widget presets

### DIFF
--- a/tests/test_looping_params.py
+++ b/tests/test_looping_params.py
@@ -1,0 +1,63 @@
+import dnnlib
+from widgets.looping_widget import LoopingWidget
+
+
+class QueueStub:
+    def __init__(self):
+        self.items = []
+
+    def put(self, item):
+        self.items.append(item)
+
+
+def make_widget():
+    w = LoopingWidget.__new__(LoopingWidget)
+    w.params = dnnlib.EasyDict(num_keyframes=6, mode=True, anim=False, index=0,
+                               looptime=4, perfect_loop=False)
+    w.keyframes = ["kf"] * 6
+    w.alpha = 0
+    w.expand_vec = False
+    w.seeds = [[i, 0] for i in range(6)]
+    w.modes = [0] * 6
+    w.project = [True] * 6
+    w.paths = [""] * 6
+    w.loop_type = True
+    w.radius = 1.0
+    w.noise_seed = 0
+    w.args_queue = QueueStub()
+    return w
+
+
+def test_roundtrip_preserves_noise_loop_state():
+    src = make_widget()
+    src.params.anim = True
+    src.loop_type = False  # NoiseLoop mode
+    src.radius = 10.0
+    src.noise_seed = 7
+    dst = make_widget()
+    dst.set_params(src.get_params())
+    assert dst.loop_type is False
+    assert dst.radius == 10.0
+    assert dst.noise_seed == 7
+    assert dst.params.anim is True
+
+
+def test_load_resyncs_noise_loop_worker():
+    src = make_widget()
+    src.loop_type = False
+    src.radius = 10.0
+    src.noise_seed = 7
+    dst = make_widget()
+    dst.set_params(src.get_params())
+    assert dst.args_queue.items == [(7, 10.0)]
+
+
+def test_legacy_12_tuple_still_loads():
+    legacy = (6, ["kf"] * 6, 0, 0, True, False, 4, False,
+              [[i, 0] for i in range(6)], [0] * 6, [True] * 6, [""] * 6)
+    dst = make_widget()
+    dst.set_params(legacy)
+    assert dst.loop_type is True
+    assert dst.radius == 1.0
+    assert dst.noise_seed == 0
+    assert dst.args_queue.items == []

--- a/tests/test_renderer_conditional.py
+++ b/tests/test_renderer_conditional.py
@@ -1,0 +1,35 @@
+import torch
+
+import dnnlib
+from architectures.networks_stylegan2 import MappingNetwork
+from widgets.renderer import Renderer
+
+
+def make_renderer():
+    r = Renderer.__new__(Renderer)
+    r._device = torch.device("cpu")
+    return r
+
+
+def make_g(c_dim):
+    net = MappingNetwork(z_dim=16, c_dim=c_dim, w_dim=16, num_ws=4,
+                         num_layers=1)
+    return dnnlib.EasyDict(mapping=net, c_dim=c_dim, num_ws=4)
+
+
+def test_process_vec_projects_with_conditional_model():
+    out = make_renderer().process_vec(make_g(c_dim=3), torch.randn(16),
+                                      True, 1, None)
+    assert out.shape == (1, 4, 16)
+
+
+def test_process_vec_projects_with_unconditional_model():
+    out = make_renderer().process_vec(make_g(c_dim=0), torch.randn(16),
+                                      True, 1, None)
+    assert out.shape == (1, 4, 16)
+
+
+def test_process_vec_without_project():
+    out = make_renderer().process_vec(make_g(c_dim=3), torch.randn(16),
+                                      False, 1, None)
+    assert out.shape == (1, 4, 16)

--- a/widgets/looping_widget.py
+++ b/widgets/looping_widget.py
@@ -203,10 +203,16 @@ class LoopingWidget:
 
     def get_params(self):
         return self.params.num_keyframes, self.keyframes, self.alpha, self.params.index, self.params.mode, self.params.anim, self.params.looptime, \
-            self.expand_vec, self.seeds, self.modes, self.project, self.paths
+            self.expand_vec, self.seeds, self.modes, self.project, self.paths, self.loop_type, self.radius, self.noise_seed
 
     def set_params(self, params):
-        self.params.num_keyframes, self.keyframes, self.alpha, self.params.index, self.params.mode, self.params.anim, self.params.looptime, self.expand_vec, self.seeds, self.modes, self.project, self.paths = params
+        # Presets saved before the noise loop state was included hold 12 values.
+        self.params.num_keyframes, self.keyframes, self.alpha, self.params.index, self.params.mode, self.params.anim, self.params.looptime, self.expand_vec, self.seeds, self.modes, self.project, self.paths, *rest = params
+        if rest:
+            self.loop_type, self.radius, self.noise_seed = rest
+            # The noise loop features live in a worker process. Resync it, the
+            # same way the UI does when the seed or radius fields change.
+            self.args_queue.put((self.noise_seed, self.radius))
 
     def drag(self, idx, dx, dy):
         viz = self.viz

--- a/widgets/renderer.py
+++ b/widgets/renderer.py
@@ -566,6 +566,7 @@ class Renderer:
                     if vec.shape[0] == 1:
                         try:
                             all_cs = np.zeros([len(vec), G.c_dim], dtype=np.float32)
+                            all_cs = self.to_device(torch.from_numpy(all_cs))
                             w = self.to_device(vec)
                             if project:
                                 w = mapping_net(z=w, c=all_cs, truncation_psi=trunc_psi, truncation_cutoff=trunc_cutoff)
@@ -864,6 +865,7 @@ class Renderer:
         latent = self.to_device(latent[None, ...])
         if project and len(latent.shape) == 2:
             all_cs = np.zeros([len(latent), G.c_dim], dtype=np.float32)
+            all_cs = self.to_device(torch.from_numpy(all_cs))
             latent = mapping_net(latent, all_cs, truncation_psi=trunc_psi,
                                truncation_cutoff=trunc_cutoff)
 


### PR DESCRIPTION
## Summary

Presets saved in NoiseLoop mode reloaded in Keyframe mode with default radius and seed, because the looping widget's saved tuple omitted `loop_type`, `radius`, and `noise_seed`. The tuple now includes them, and loading resyncs the noise loop worker process so the restored radius actually drives the motion.

## Related issue

Closes #56
Closes #58

Also fixes vec-mode rendering with class-conditional models (#58): the renderer passed the conditioning vector to the mapping network as raw numpy, which raises `'numpy.ndarray' object has no attribute 'to'` whenever `c_dim > 0` and, in the main vec path, left an un-mapped latent that crashed at `w += direction`. Both affected call sites in `widgets/renderer.py` (the `_render_impl` vec branch and `process_vec`) now convert with `to_device(torch.from_numpy(...))`, matching the seed-mode branch. Present since at least v2.17.0; surfaced by NoiseLoop, which renders through vec mode.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Other (docs, refactor, chore, ci, etc.)

## How was this tested?

- `uv run pytest`: 162 passed, including 3 new tests in `tests/test_looping_params.py` pinning the round-trip of the three new fields, the worker-queue resync on load, and backward compatibility with legacy 12-value preset files (which load unchanged and keep session defaults).
- 3 new tests in `tests/test_renderer_conditional.py` exercise `process_vec` against a small conditional and unconditional `MappingNetwork` on CPU; the conditional case reproduced the exact field failure before the fix.
- Needs manual verification: with a conditional model (e.g. WikiArt), enable NoiseLoop and confirm it renders without the mapping warning; also save a preset in NoiseLoop mode with radius 10, restart, load it, and confirm the widget returns to NoiseLoop at radius 10 with matching loop motion. Presets saved before this fix do not contain the state and need one re-save.

## Checklist

- [x] PR title follows Conventional Commits without a scope (`<type>: <subject>`)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Documentation in `docs/` or `README.md` is updated if user-visible behavior changed (no user-visible behavior change beyond the bug fix)
- [x] If this PR adds new runtime files, they are included in `release.py` (no new runtime files)
- [ ] Screenshots or a short clip are attached for UI changes (not a UI change)

Generated with AI assistance
