### PR TITLE
fix: clone published latent vec so vec anim renders without cuda

### DIFF
--- a/tests/test_latent_widget_args.py
+++ b/tests/test_latent_widget_args.py
@@ -1,0 +1,41 @@
+import imgui
+import pytest
+import torch
+
+import dnnlib
+from modules.renderloop import compare_args
+from widgets.latent_widget import LatentWidget
+
+
+@pytest.fixture(autouse=True)
+def no_imgui_ids(monkeypatch):
+    monkeypatch.setattr(imgui, "push_id", lambda *_: None)
+    monkeypatch.setattr(imgui, "pop_id", lambda: None)
+
+
+def make_widget():
+    w = LatentWidget.__new__(LatentWidget)
+    w.latent = dnnlib.EasyDict(vec=torch.randn(1, 512), next=torch.randn(1, 512),
+                               x=0, y=0, frac_x=0., frac_y=0.,
+                               update_mode=1, speed=0.25, mode=False, project=True)
+    w.viz = dnnlib.EasyDict(args=dnnlib.EasyDict(),
+                            app=dnnlib.EasyDict(frame_delta=1 / 60))
+    return w
+
+
+def test_vec_anim_step_is_visible_to_render_args_gate():
+    w = make_widget()
+    w(show=False)
+    frame1 = dict(w.viz.args)
+    w.update_vec()
+    w(show=False)
+    frame2 = dict(w.viz.args)
+    assert not compare_args(frame1, frame2)
+
+
+def test_published_vec_does_not_alias_widget_state():
+    w = make_widget()
+    w(show=False)
+    published = w.viz.args.vec
+    w.latent.vec += 1.0
+    assert not torch.equal(published, w.latent.vec)

--- a/widgets/latent_widget.py
+++ b/widgets/latent_widget.py
@@ -77,7 +77,7 @@ class LatentWidget:
         self.viz.args.mode = self.latent.mode
         self.viz.args.project = self.latent.project
         self.viz.args.seed = [self.latent.x, self.latent.y]  # [[seed, weight], ...]
-        self.viz.args.vec = self.latent.vec.pin_memory() if torch.cuda.is_available() else self.latent.vec
+        self.viz.args.vec = self.latent.vec.pin_memory() if torch.cuda.is_available() else self.latent.vec.clone()
 
     def drag(self, dx, dy):
         viz = self.viz
@@ -246,7 +246,9 @@ class LatentWidget:
                     self.update_vec()
                 self.update = False
         viz.args.seeds = (self.latent.x, self.latent.y)
-        viz.args.vec = self.latent.vec.pin_memory() if torch.cuda.is_available() else self.latent.vec
+        # Publish a copy: update_vec() mutates latent.vec in place, and an
+        # aliased tensor defeats the renderer's change detection (set_args).
+        viz.args.vec = self.latent.vec.pin_memory() if torch.cuda.is_available() else self.latent.vec.clone()
 
 
 


### PR DESCRIPTION
## Summary

In Vector mode, `update_vec()` mutates `latent.vec` in place, and on non-CUDA platforms the same tensor object was published to `viz.args` every frame. The renderer change gate (`compare_args` in `AsyncRenderer.set_args`) then compared the tensor against itself, saw no change, and never rendered — freezing vec-mode animation on macOS. This publishes a `clone()` on the non-CUDA branch instead, mirroring the per-frame copy that `pin_memory()` already makes on CUDA.

## Related issue

Closes #59

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Other (docs, refactor, chore, ci, etc.)

## How was this tested?

- Added `tests/test_latent_widget_args.py`: one test drives two publish cycles with an `update_vec()` animation step between them and asserts the real gate (`compare_args` from `modules/renderloop.py`) detects the change; the other asserts the published vec does not alias widget state. Both failed before the fix for exactly the diagnosed reason and pass after.
- Full suite: `uv run pytest` — 167 passed.
- **Needs manual verification on macOS**: load a model, switch to Vector mode, press Anim — the image should drift continuously. Seed mode and CUDA platforms should behave unchanged (CUDA takes the `pin_memory()` path, untouched).

## Checklist

- [x] PR title follows Conventional Commits without a scope (`<type>: <subject>`)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Documentation in `docs/` or `README.md` is updated if user-visible behavior changed (no user-visible behavior change beyond the bug fix)
- [x] If this PR adds new runtime files, they are included in `release.py` (no new runtime files)
- [ ] Screenshots or a short clip are attached for UI changes (no UI change)

Generated with AI assistance
