### PR TITLE
fix: keep log rotation failures from snowballing into a record storm

### DIFF
--- a/tests/test_app_logging_rotation.py
+++ b/tests/test_app_logging_rotation.py
@@ -1,0 +1,101 @@
+"""Log rotation contention must not take logging down (autolume#63).
+
+On Windows the midnight rename of autolume.log fails with WinError 32 while
+any other process holds the file (a second instance, antivirus, backup). The
+stock TimedRotatingFileHandler then drops every record and retries the rename
+per record, and its handleError reports to sys.stderr — which the app
+redirects back into logging, snowballing one failure into an unbounded record
+storm that exhausted the reporter's machine.
+"""
+import logging
+import time
+
+import pytest
+
+from utils.app_logging import (_ResilientTimedRotatingFileHandler,
+                               _mute_handler_feedback)
+
+
+def record(msg="hello"):
+    return logging.LogRecord("test", logging.INFO, __file__, 1, msg, None, None)
+
+
+@pytest.fixture
+def handler(tmp_path):
+    h = _ResilientTimedRotatingFileHandler(
+        str(tmp_path / "autolume.log"), when="midnight", backupCount=3,
+        encoding="utf-8", delay=True)
+    yield h
+    h.close()
+
+
+def test_rotation_failure_falls_back_to_current_file(handler, tmp_path, monkeypatch):
+    handler.emit(record("before"))
+    handler.rolloverAt = int(time.time()) - 3600
+    monkeypatch.setattr(handler, "rotate", lambda src, dst: (_ for _ in ()).throw(
+        PermissionError(32, "held by another process")))
+
+    handler.emit(record("during contention"))
+
+    text = (tmp_path / "autolume.log").read_text(encoding="utf-8")
+    assert "during contention" in text
+    assert handler.rolloverAt > int(time.time())
+
+
+def test_rotation_failure_is_reported_once_not_per_record(handler, monkeypatch, caplog):
+    handler.emit(record("before"))
+    handler.rolloverAt = int(time.time()) - 3600
+    monkeypatch.setattr(handler, "rotate", lambda src, dst: (_ for _ in ()).throw(
+        PermissionError(32, "held by another process")))
+
+    with caplog.at_level(logging.WARNING, logger="autolume"):
+        for i in range(50):
+            handler.emit(record("record %d" % i))
+
+    postponed = [r for r in caplog.records if "rotation postponed" in r.message]
+    assert len(postponed) == 1
+
+
+def test_foreign_rotation_reschedules_the_next_rollover(handler, tmp_path):
+    # When another instance already created the dated backup, the stock
+    # doRollover returns early with rolloverAt still in the past, re-entering
+    # rotation on every subsequent record forever.
+    handler.emit(record("before"))
+    handler.rolloverAt = int(time.time()) - 3600
+    suffix = time.strftime(handler.suffix,
+                           time.localtime(handler.rolloverAt - handler.interval))
+    (tmp_path / ("autolume.log." + suffix)).touch()
+
+    handler.emit(record("after foreign rotation"))
+
+    assert handler.rolloverAt > int(time.time())
+    text = (tmp_path / "autolume.log").read_text(encoding="utf-8")
+    assert "after foreign rotation" in text
+
+
+def test_handler_failures_stay_out_of_stderr(monkeypatch):
+    # sys.stderr is _StreamToLogger in every Autolume process: anything a
+    # handler writes there re-enters the logging pipeline as new records.
+    class Broken:
+        def write(self, text):
+            raise OSError("disk full")
+
+        def flush(self):
+            pass
+
+    writes = []
+
+    class Probe:
+        def write(self, text):
+            writes.append(text)
+
+        def flush(self):
+            pass
+
+    import sys
+    monkeypatch.setattr(sys, "stderr", Probe())
+    h = _mute_handler_feedback(logging.StreamHandler(Broken()))
+
+    h.handle(record("boom"))  # must neither raise nor touch sys.stderr
+
+    assert writes == []

--- a/utils/app_logging.py
+++ b/utils/app_logging.py
@@ -30,6 +30,7 @@ import re
 import sys
 import tempfile
 import threading
+import time
 import traceback
 
 LOG_DIR_NAME = "logs"
@@ -114,6 +115,56 @@ class _StreamToLogger:
         return False
 
 
+class _ResilientTimedRotatingFileHandler(logging.handlers.TimedRotatingFileHandler):
+    """Rotation failure must not take logging down with it.
+
+    On Windows the midnight rename fails with WinError 32 whenever any other
+    process holds the log file (a second Autolume instance, an antivirus
+    scan, a backup tool). The stock handler leaves ``rolloverAt`` in the past
+    on failure, so every subsequent record retries the rename, fails, and is
+    dropped. Instead, keep writing to the current file and retry the
+    rotation later.
+    """
+
+    ROTATE_RETRY_SECONDS = 300
+
+    def doRollover(self):
+        try:
+            super().doRollover()
+        except OSError as exc:
+            self.rolloverAt = int(time.time()) + self.ROTATE_RETRY_SECONDS
+            logging.getLogger("autolume").warning(
+                "Log rotation postponed for %ds: %s",
+                self.ROTATE_RETRY_SECONDS, exc)
+        else:
+            # When another process already created the dated backup, the
+            # stock doRollover returns early without scheduling the next
+            # rollover; catch up so we don't re-enter it on every record.
+            now = int(time.time())
+            if self.rolloverAt <= now:
+                self.rolloverAt = self.computeRollover(now)
+
+
+def _mute_handler_feedback(handler):
+    """Keep a handler's own failures out of the logging pipeline.
+
+    The default ``Handler.handleError`` prints to ``sys.stderr``, which this
+    module redirects back into logging. For the handlers driven by the
+    QueueListener thread that is a feedback loop: a persistently failing
+    handler turns each failure report into ~17 new records, each of which
+    fails again, snowballing until memory runs out (autolume#63). Report to
+    the real console instead, or drop the report when there is none.
+    """
+    def handle_error(record):
+        if sys.__stderr__ is not None:
+            try:
+                traceback.print_exc(file=sys.__stderr__)
+            except Exception:
+                pass
+    handler.handleError = handle_error
+    return handler
+
+
 def _configure_root(log_queue, level):
     root = logging.getLogger()
     root.handlers.clear()
@@ -175,17 +226,17 @@ def setup_main_logging(level=None):
     log_dir = _resolve_log_dir()
     if log_dir is not None:
         try:
-            file_handler = logging.handlers.TimedRotatingFileHandler(
+            file_handler = _ResilientTimedRotatingFileHandler(
                 str(log_dir / LOG_FILE_NAME), when="midnight",
                 backupCount=BACKUP_DAYS, encoding="utf-8", delay=True)
             file_handler.setFormatter(formatter)
-            handlers.append(file_handler)
+            handlers.append(_mute_handler_feedback(file_handler))
         except Exception:
             log_dir = None
     if sys.__stderr__ is not None:
         console_handler = logging.StreamHandler(sys.__stderr__)
         console_handler.setFormatter(formatter)
-        handlers.append(console_handler)
+        handlers.append(_mute_handler_feedback(console_handler))
 
     _log_queue = multiprocessing.get_context("spawn").Queue(-1)
     _listener = logging.handlers.QueueListener(


### PR DESCRIPTION
Fixes #63

## Problem

When another process holds `autolume.log` (a second Autolume instance, an antivirus scan, a backup tool), the midnight rename fails with WinError 32. Two coupled defects then turn that one benign failure into a crash:

1. The stock `TimedRotatingFileHandler` leaves `rolloverAt` in the past on failure, so **every subsequent record retries the rename, fails, and is dropped**.
2. Each failure is reported through `Handler.handleError`, which writes to `sys.stderr` — redirected by `_install_runtime_capture` back into the logging pipeline, so each failure re-enters the queue as ~17 new records.

Reproduced with a harness driving the real `app_logging` stack: a single log line under contention amplified to ~50k records in 2 s (~25k records/s, matching the crash report's ~22k lines/s burst); with the handle held, queue growth is unbounded (~20 MB/s RSS) until commit exhaustion — which is what surfaced as `OSError: [WinError 1450]` in the frame loop's `time.sleep` in the field. Two real instances sharing a data root reproduce it with no artificial holder. Full repro data in [the issue comment](https://github.com/Metacreation-Lab/autolume/issues/63#issuecomment-5362284535).

## Fix

Scoped to the two defects, in `utils/app_logging.py`:

- **`_ResilientTimedRotatingFileHandler`** — on rotation failure, keep writing to the current file and retry in 5 minutes, logging one postponement warning instead of failing per record. When another instance already created the dated backup (the stdlib early-return path), reschedule the next rollover instead of re-entering rotation on every record.
- **`_mute_handler_feedback`** — the QueueListener-side handlers report their own failures to the real console (`sys.__stderr__`) only, never to the redirected `sys.stderr`, so a persistently failing handler (rotation contention, disk full) can no longer feed its own error reports back to itself.

Deliberately **not** included (downstream hardening, separate concerns): guarding the FPS-limiter `time.sleep`, `finally` around the main loop, a single-instance lock, daemonizing training children, codecarbon/NVML changes.

## Verification

- New regression tests in `tests/test_app_logging_rotation.py`: fallback to the current file, single postponement warning per failure window, rescheduling after a foreign rotation, and handler failures staying out of `sys.stderr`.
- Repro harness re-run against the fix: every storm scenario now yields a handful of records with zero log loss (records keep flowing to the current file during contention, rotation succeeds on retry after the holder releases); a persistent disk-full-class emit failure no longer amplifies (51 logged → 51 enqueued, memory flat).
- Full suite: 174 passed; the one failure (`test_presets.py::test_external_changes_are_picked_up`) is a pre-existing order-dependent flake that also fails on the clean tree.
