### PR TITLE
fix: probe video durations off the gui thread on import

### DIFF
--- a/modules/preprocessing_module.py
+++ b/modules/preprocessing_module.py
@@ -10,7 +10,7 @@ from widgets.thumbnail_widget import ThumbnailWidget
 from widgets.image_preview_widget import ImagePreviewWidget
 from widgets.loading_widget import LoadingOverlayManager
 from widgets.help_icon_widget import HelpIconWidget
-from utils.dataset_preprocessing_utils import DatasetPreprocessingUtils
+from utils.dataset_preprocessing_utils import DatasetPreprocessingUtils, VideoDurationProber
 
 resize_mode = ['stretch','center crop']
 padding_color = ['black', 'white', 'bleeding']
@@ -40,6 +40,7 @@ class DataPreprocessing:
         # Video frame extraction
         self.fps = self.settings.fps
         self.video_durations = {}
+        self.duration_prober = VideoDurationProber()
         self.video_extraction_queue = mp.Queue()
         self.video_extraction_reply = mp.Queue()
         self.is_processing_video = False
@@ -166,14 +167,10 @@ class DataPreprocessing:
         if imgui.button("Import Videos", width=parameter_column_width, height=30):
             self.selected_video_files = self.data_browser.select_video_files()
             if self.selected_video_files:
-                # Reset cache variables when opening popup with new videos
                 if hasattr(self, 'last_video_count'):
                     delattr(self, 'last_video_count')
-                if hasattr(self, 'last_fps'):
-                    delattr(self, 'last_fps')
-                if hasattr(self, 'last_expected_frames'):
-                    delattr(self, 'last_expected_frames')
                 self.video_durations = {}
+                self.duration_prober.start(self.selected_video_files)
                 imgui.open_popup("Video Frame Extraction")
 
         # Video Frame Extraction Popup
@@ -251,7 +248,9 @@ class DataPreprocessing:
                             self.thumbnail_widget.update_thumbnails(self.imported_files)
 
                             # Reset variables
-                            self.selected_video_files = [] 
+                            self.selected_video_files = []
+                            self.video_durations = {}
+                            self.duration_prober.cancel()
                             self.is_processing_video = False
                             self.loading_widget.hide()
                             self.fps = self.settings.fps 
@@ -273,14 +272,10 @@ class DataPreprocessing:
 
             if imgui_utils.button("Close", width=left_popup_width - 10, enabled=True):
                 self.selected_video_files = []
-                # Reset cache variables when closing popup
                 if hasattr(self, 'last_video_count'):
                     delattr(self, 'last_video_count')
-                if hasattr(self, 'last_fps'):
-                    delattr(self, 'last_fps')
-                if hasattr(self, 'last_expected_frames'):
-                    delattr(self, 'last_expected_frames')
                 self.video_durations = {}
+                self.duration_prober.cancel()
                 imgui.close_current_popup()
             imgui.end_child()
 
@@ -312,20 +307,16 @@ class DataPreprocessing:
             
             imgui.end_child() # Thumbnail Video Scroll
                         
-            # Only recalculate frames if FPS or video list changed
-            if (not hasattr(self, 'last_fps') or self.fps != self.last_fps or 
-                not hasattr(self, 'last_video_count') or len(self.selected_video_files) != self.last_video_count):
-                expected_frames = 0
-                for video_path in self.selected_video_files:
-                    if video_path not in self.video_durations:
-                        self.video_durations[video_path] = DatasetPreprocessingUtils.calculate_video_duration(video_path)
-                    duration = self.video_durations[video_path]
-                    expected_frames += int(duration * self.fps) if duration > 0 else 0
-                self.last_expected_frames = expected_frames
-                self.last_fps = self.fps
-                self.last_video_count = len(self.selected_video_files)
-            
-            imgui.text(f"Expected frames extracted: {getattr(self, 'last_expected_frames', 0)}")
+            # Durations are probed on background threads (ffprobe spawns are
+            # too slow for the GUI thread in the frozen build); the count
+            # fills in as results arrive.
+            self.video_durations.update(self.duration_prober.poll())
+            expected_frames = sum(int(self.video_durations[p] * self.fps)
+                                  for p in self.selected_video_files
+                                  if self.video_durations.get(p, 0) > 0)
+            pending = any(p not in self.video_durations for p in self.selected_video_files)
+            imgui.text(f"Expected frames extracted: {expected_frames}"
+                       + (" (calculating...)" if pending else ""))
 
             imgui.same_line(position=video_available_width - 50)
             if imgui.button("Remove"):
@@ -339,11 +330,6 @@ class DataPreprocessing:
 
                 self.video_thumbnail_widget.update_thumbnails(self.selected_video_files)
                 self.video_thumbnail_widget.clear_selected()
-
-                if hasattr(self, 'last_fps'):
-                    delattr(self, 'last_fps')
-                if hasattr(self, 'last_expected_frames'):
-                    delattr(self, 'last_expected_frames')
 
             imgui.end_child() # Video popup right
 
@@ -883,6 +869,8 @@ class DataPreprocessing:
                 self.loading_widget.cleanup()
             if hasattr(self, 'help_icon') and self.help_icon is not None:
                 self.help_icon.cleanup()
+            if hasattr(self, 'duration_prober') and self.duration_prober is not None:
+                self.duration_prober.shutdown()
                 
         except Exception as e:
             logger.warning("Error during cleanup: %s", e)

--- a/super_res/super_res.py
+++ b/super_res/super_res.py
@@ -7,6 +7,7 @@ import os
 import argparse
 import ffmpeg
 import cv2
+from utils import ffmpeg_utils
 from torchvision import transforms
 from super_res.net_base import SRVGGNetPlus, SRVGGNetCompact, RRDBNet
 from utils.device_utils import get_device
@@ -91,14 +92,14 @@ def check_width_height(args):
 
 
 def get_resolution(video_path):
-  probe = ffmpeg.probe(video_path)
+  probe = ffmpeg_utils.probe(video_path)
   video_streams = [stream for stream in probe['streams'] if stream['codec_type'] == 'video']
   w = video_streams[0]['width']
   h = video_streams[0]['height']
   return w,h
 
 def get_audio(video_path):
-  probe = ffmpeg.probe(video_path)
+  probe = ffmpeg_utils.probe(video_path)
   has_audio = any(stream['codec_type'] == 'audio' for stream in probe['streams'])
   audio=ffmpeg.input(video_path).audio if has_audio else None
   return audio
@@ -107,10 +108,10 @@ class Reader:
     def __init__(self, width, height, video_path):
       self.width=width
       self.height=height
-      self.stream_reader = (
+      self.stream_reader = ffmpeg_utils.run_async(
                 ffmpeg.input(video_path).output('pipe:', format='rawvideo', pix_fmt='bgr24',
-                                                loglevel='error').run_async(
-                                                    pipe_stdin=True, pipe_stdout=True))
+                                                loglevel='error'),
+                pipe_stdin=True, pipe_stdout=True)
     def get_frame_from_stream(self):
         img_bytes = self.stream_reader.stdout.read(self.width * self.height * 3)  # 3 bytes for one pixel
         if not img_bytes:
@@ -133,7 +134,7 @@ class Writer:
           out_width, out_height = int(args.out_width), int(args.out_width)
 
         if audio is not None:
-            self.stream_writer = (
+            self.stream_writer = ffmpeg_utils.run_async(
                 ffmpeg.input('pipe:', format='rawvideo', pix_fmt='bgr24', s=f'{out_width}x{out_height}',
                              framerate=fps).output(
                                  audio,
@@ -141,17 +142,17 @@ class Writer:
                                  pix_fmt='yuv420p',
                                  vcodec='libx264',
                                  loglevel='error',
-                                 acodec='copy').overwrite_output().run_async(
-                                     pipe_stdin=True, pipe_stdout=True,cmd='ffmpeg'))
+                                 acodec='copy').overwrite_output(),
+                pipe_stdin=True, pipe_stdout=True)
         else:
-            self.stream_writer = (
+            self.stream_writer = ffmpeg_utils.run_async(
                 ffmpeg.input('pipe:', format='rawvideo',
                 pix_fmt='bgr24',
                 s=f'{out_width}x{out_height}',
                              framerate=fps).output(
                                  video_save_path, pix_fmt='yuv420p',vcodec='libx264',
-                                 loglevel='error').overwrite_output().run_async(
-                                     pipe_stdin=True, pipe_stdout=True,cmd='ffmpeg'))
+                                 loglevel='error').overwrite_output(),
+                pipe_stdin=True, pipe_stdout=True)
 
     def write_frame(self, frame):
         frame = frame.tobytes()

--- a/tests/test_ffmpeg_utils.py
+++ b/tests/test_ffmpeg_utils.py
@@ -1,0 +1,68 @@
+import json
+import subprocess
+
+import ffmpeg
+import pytest
+
+from utils import ffmpeg_utils
+
+
+def test_probe_parses_json_and_hides_window(monkeypatch):
+    seen = {}
+
+    def fake_run(args, capture_output, creationflags):
+        seen["args"] = args
+        seen["creationflags"] = creationflags
+        stdout = json.dumps({"streams": [], "format": {"duration": "5.0"}}).encode()
+        return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr=b"")
+
+    monkeypatch.setattr(ffmpeg_utils.subprocess, "run", fake_run)
+    result = ffmpeg_utils.probe("video.mp4")
+
+    assert result["format"]["duration"] == "5.0"
+    assert seen["args"] == ["ffprobe", "-show_format", "-show_streams", "-of", "json", "video.mp4"]
+    assert seen["creationflags"] == ffmpeg_utils.CREATIONFLAGS
+
+
+def test_probe_raises_ffmpeg_error_on_failure(monkeypatch):
+    def fake_run(args, capture_output, creationflags):
+        return subprocess.CompletedProcess(args, 1, stdout=b"", stderr=b"boom")
+
+    monkeypatch.setattr(ffmpeg_utils.subprocess, "run", fake_run)
+    with pytest.raises(ffmpeg.Error) as excinfo:
+        ffmpeg_utils.probe("video.mp4")
+    assert excinfo.value.stderr == b"boom"
+
+
+def test_run_async_compiles_stream_and_hides_window(monkeypatch):
+    seen = {}
+
+    def fake_popen(args, stdin, stdout, creationflags):
+        seen.update(args=args, stdin=stdin, stdout=stdout, creationflags=creationflags)
+        return "process"
+
+    monkeypatch.setattr(ffmpeg_utils.subprocess, "Popen", fake_popen)
+    stream = ffmpeg.input("in.mp4").output("out.mp4", vf="fps=10")
+    process = ffmpeg_utils.run_async(stream, pipe_stdout=True)
+
+    assert process == "process"
+    assert seen["args"][0] == "ffmpeg"
+    assert seen["args"][-1] == "out.mp4"
+    assert "fps=10" in seen["args"]
+    assert seen["stdin"] is None
+    assert seen["stdout"] == subprocess.PIPE
+    assert seen["creationflags"] == ffmpeg_utils.CREATIONFLAGS
+
+
+def test_run_async_pipe_stdin(monkeypatch):
+    seen = {}
+
+    def fake_popen(args, stdin, stdout, creationflags):
+        seen.update(stdin=stdin, stdout=stdout)
+        return "process"
+
+    monkeypatch.setattr(ffmpeg_utils.subprocess, "Popen", fake_popen)
+    ffmpeg_utils.run_async(ffmpeg.input("pipe:").output("out.mp4"), pipe_stdin=True)
+
+    assert seen["stdin"] == subprocess.PIPE
+    assert seen["stdout"] is None

--- a/tests/test_video_duration_prober.py
+++ b/tests/test_video_duration_prober.py
@@ -1,0 +1,63 @@
+import time
+
+import pytest
+
+from utils.dataset_preprocessing_utils import VideoDurationProber
+
+
+def poll_until(prober, expected_count, timeout=5.0):
+    """Collect poll() results until expected_count paths arrived or timeout."""
+    results = {}
+    deadline = time.monotonic() + timeout
+    while len(results) < expected_count and time.monotonic() < deadline:
+        results.update(prober.poll())
+        time.sleep(0.01)
+    return results
+
+
+@pytest.fixture
+def prober(request):
+    def make(probe_fn):
+        p = VideoDurationProber(probe_fn=probe_fn)
+        request.addfinalizer(p.shutdown)
+        return p
+    return make
+
+
+def test_results_arrive_via_poll(prober):
+    p = prober(lambda path: {"a.mp4": 10.0, "b.mp4": 2.5}[path])
+    p.start(["a.mp4", "b.mp4"])
+    assert poll_until(p, 2) == {"a.mp4": 10.0, "b.mp4": 2.5}
+
+
+def test_poll_with_nothing_pending_returns_empty(prober):
+    p = prober(lambda path: 1.0)
+    assert p.poll() == {}
+    p.start(["a.mp4"])
+    poll_until(p, 1)
+    assert p.poll() == {}
+
+
+def test_cancel_discards_in_flight_results(prober):
+    p = prober(lambda path: 1.0)
+    p.start(["a.mp4"])
+    # Let the probe finish before cancelling so its result is queued but stale.
+    time.sleep(0.2)
+    p.cancel()
+    assert poll_until(p, 1, timeout=0.3) == {}
+
+
+def test_restart_discards_previous_generation(prober):
+    p = prober(lambda path: 1.0 if path == "old.mp4" else 2.0)
+    p.start(["old.mp4"])
+    time.sleep(0.2)
+    p.start(["new.mp4"])
+    assert poll_until(p, 1) == {"new.mp4": 2.0}
+
+
+def test_failing_probe_reports_zero_duration(prober):
+    def probe(path):
+        raise RuntimeError("ffprobe exploded")
+    p = prober(probe)
+    p.start(["broken.mp4"])
+    assert poll_until(p, 1) == {"broken.mp4": 0}

--- a/utils/dataset_preprocessing_utils.py
+++ b/utils/dataset_preprocessing_utils.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import queue
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import numpy as np
@@ -12,6 +14,59 @@ import ffmpeg
 from utils.user_data import data_path
 
 logger = logging.getLogger(__name__)
+
+
+class VideoDurationProber:
+    """Probes video durations on background threads so the GUI never blocks
+    on ffprobe subprocess spawns (issue #62: each spawn of the bundled
+    ffprobe.exe can stall for hundreds of ms in the frozen Windows build).
+
+    Same executor/queue/generation idiom as ThumbnailWidget: start() submits
+    probes, poll() drains finished ones, and bumping the generation makes
+    in-flight results stale so they are silently dropped.
+    """
+
+    def __init__(self, probe_fn=None):
+        self._probe_fn = probe_fn or DatasetPreprocessingUtils.calculate_video_duration
+        self._executor = None
+        self._results = queue.Queue()  # (generation, path, duration)
+        self._generation = 0
+
+    def start(self, paths):
+        """Probe each path in the background; results arrive via poll()."""
+        self._generation += 1
+        if self._executor is None:
+            self._executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="duration-probe")
+        for path in paths:
+            self._executor.submit(self._probe, path, self._generation)
+
+    def poll(self):
+        """Return {path: duration} for probes finished since the last call."""
+        fresh = {}
+        while True:
+            try:
+                generation, path, duration = self._results.get_nowait()
+            except queue.Empty:
+                return fresh
+            if generation == self._generation:
+                fresh[path] = duration
+
+    def cancel(self):
+        """Discard results from probes still in flight."""
+        self._generation += 1
+
+    def shutdown(self):
+        if self._executor is not None:
+            self._executor.shutdown(wait=False, cancel_futures=True)
+            self._executor = None
+
+    def _probe(self, path, generation):
+        try:
+            duration = self._probe_fn(path)
+        except Exception as e:
+            logger.warning("Could not probe duration of %s: %s", path, e)
+            duration = 0
+        self._results.put((generation, path, duration))
 
 
 class DatasetPreprocessingUtils:

--- a/utils/dataset_preprocessing_utils.py
+++ b/utils/dataset_preprocessing_utils.py
@@ -11,6 +11,7 @@ import PIL.ImageOps
 import torchvision.transforms as transforms
 import ffmpeg
 
+from utils import ffmpeg_utils
 from utils.user_data import data_path
 
 logger = logging.getLogger(__name__)
@@ -184,7 +185,7 @@ class DatasetPreprocessingUtils:
 
     @staticmethod
     def calculate_video_duration(video_path):
-        probe = ffmpeg.probe(video_path)
+        probe = ffmpeg_utils.probe(video_path)
         video_info = next(s for s in probe['streams'] if s['codec_type'] == 'video')
 
         duration = None
@@ -275,12 +276,12 @@ class DatasetPreprocessingUtils:
                 'percentage': start_pct,
             })
 
-            process = (
+            process = ffmpeg_utils.run_async(
                 ffmpeg
                 .input(video_path)
                 .output(output_pattern, vf=f"fps={fps}")
-                .global_args('-progress', 'pipe:1', '-nostats')
-                .run_async(pipe_stdout=True)
+                .global_args('-progress', 'pipe:1', '-nostats'),
+                pipe_stdout=True,
             )
 
             cancelled = False

--- a/utils/ffmpeg_utils.py
+++ b/utils/ffmpeg_utils.py
@@ -1,0 +1,34 @@
+"""Windowless launchers for ffmpeg/ffprobe.
+
+ffmpeg-python starts its subprocesses with a bare Popen; from the windowed
+release build every such spawn allocates a new console, which on Windows 11
+opens a Windows Terminal window per probe/encode (and those can outlive the
+process). All runtime ffmpeg/ffprobe launches must go through these helpers.
+"""
+
+import json
+import os
+import subprocess
+
+import ffmpeg
+
+CREATIONFLAGS = subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0
+
+
+def probe(filename, cmd="ffprobe"):
+    """Drop-in for ffmpeg.probe() minus the console window on Windows."""
+    args = [cmd, "-show_format", "-show_streams", "-of", "json", filename]
+    p = subprocess.run(args, capture_output=True, creationflags=CREATIONFLAGS)
+    if p.returncode != 0:
+        raise ffmpeg.Error("ffprobe", p.stdout, p.stderr)
+    return json.loads(p.stdout.decode("utf-8"))
+
+
+def run_async(stream, pipe_stdin=False, pipe_stdout=False):
+    """Drop-in for stream.run_async() minus the console window on Windows."""
+    return subprocess.Popen(
+        ffmpeg.compile(stream),
+        stdin=subprocess.PIPE if pipe_stdin else None,
+        stdout=subprocess.PIPE if pipe_stdout else None,
+        creationflags=CREATIONFLAGS,
+    )


### PR DESCRIPTION
## Summary

Two fixes for video import in the frozen Windows build:

1. **UI freeze on import (#62)**: opening the Video Frame Extraction popup ran `ffmpeg.probe()` synchronously on the render thread for every selected video. Each probe spawns the bundled 97 MB `ffprobe.exe`, which stalls for hundreds of ms per launch in the frozen build (cold image load + Defender scan of a large unsigned binary). Durations are now probed on background threads by a new `VideoDurationProber`; the popup opens immediately and the expected-frames count shows "(calculating...)" until results arrive.
2. **Console windows cascading over the app** (found while validating the above): ffmpeg-python launches ffmpeg/ffprobe with a bare `Popen`, so from the windowed release every spawn allocates a new console — on Windows 11 that opens a Windows Terminal window per probe/encode, and those windows can outlive the process. Importing + extracting six videos cascaded a dozen terminal windows. All runtime ffmpeg/ffprobe launches (dataset preprocessing and super-res) now go through `utils/ffmpeg_utils`, which replicates `ffmpeg.probe`/`run_async` with `CREATE_NO_WINDOW` on Windows. imageio-ffmpeg already hides its own windows and is untouched.

## Related issue

Closes #62

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Other (docs, refactor, chore, ci, etc.)

## How was this tested?

- `uv run pytest` — 180 passed. New tests: `tests/test_video_duration_prober.py` (result delivery via poll, empty poll, cancel discards in-flight results, restart discards previous generation, failing probe reports duration 0) and `tests/test_ffmpeg_utils.py` (probe arg construction + JSON parsing, ffmpeg.Error on failure, run_async stream compilation, pipe wiring, creationflags always passed).
- End-to-end from source (headless): ran `calculate_video_duration` and `extract_videos` through the new windowless helpers against real mp4/webm files — correct durations, 50 frames extracted per 5s video at 10 FPS, progress and completion messages intact.
- Manually reproduced the terminal-window cascade on the packaged Windows 11 build with 6 videos (mp4/avi/mov/mkv/webm/gif); import and extraction themselves completed correctly, lingering Windows Terminal windows confirmed owned by no surviving process (defterm behavior, not a process leak).
- **Needs manual verification on a rebuilt release**: import several videos → popup appears instantly, no terminal windows during probe or extraction; super-res video path also spawns no windows.

## Checklist

- [x] PR title follows Conventional Commits without a scope (`<type>: <subject>`)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Documentation in `docs/` or `README.md` is updated if user-visible behavior changed (no user-facing docs describe these internals)
- [x] If this PR adds new runtime files, they are included in `release.py` (no new runtime files; `utils/ffmpeg_utils.py` is traced by PyInstaller as a normal import)
- [ ] Screenshots or a short clip are attached for UI changes (needs a human at the desktop; only the "(calculating...)" suffix is visually new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)