### PR TITLE
refactor: migrate all video i/o to pyav

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Autolume is a no-coding generative AI system for real-time visual performances u
 | `uv run zensical serve` | Serve docs locally at http://127.0.0.1:8000 |
 | `uv run release.py` | Build the PyInstaller release (cross-platform): `dist/Autolume/` on Windows/Linux, `dist/Autolume.app` on macOS. Run it on the target OS — PyInstaller cannot cross-compile |
 
-Initial setup also requires CUDA 12.8, MSVC build tools (Windows), `ffmpeg` (Linux), pre-trained Real-ESRGAN/face-parsing models, and an FFmpeg binary on Windows. Full details in the [README](README.md#development-instructions).
+Initial setup also requires CUDA 12.8, MSVC build tools (Windows), and pre-trained Real-ESRGAN/face-parsing models. Full details in the [README](README.md#development-instructions).
 
 There is no architecture overview here on purpose (see the maintenance principle above) — explore the tree directly; [CONTRIBUTING.md](CONTRIBUTING.md#project-layout) has a directory table if you want one.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Please include a Autolume version, OS, GPU, and CUDA version for any bug — man
 
 ## Development setup
 
-The full setup (CUDA, `uv`, model downloads, FFmpeg, platform-specific dependencies) is documented in the [README's "Development instructions" section](README.md#development-instructions). Please follow it as written; the environment is sensitive (Python 3.12, CUDA 12.8, pinned PyTorch 2.8 wheel).
+The full setup (CUDA, `uv`, model downloads, platform-specific dependencies) is documented in the [README's "Development instructions" section](README.md#development-instructions). Please follow it as written; the environment is sensitive (Python 3.12, CUDA 12.8, pinned PyTorch 2.8 wheel).
 
 Quick reference once your environment is ready:
 

--- a/README.md
+++ b/README.md
@@ -61,18 +61,15 @@ For examples of artworks created with Autolume see: https://www.metacreation.net
   - Minimum components: CUDA Development + CUDA Runtime
 - Microsoft C++ Build Tools ([download link](https://download.visualstudio.microsoft.com/download/pr/13907dbe-8bb3-4cfe-b0ae-147e70f8b2f3/a3193e6e6135ef7f598d6a9e429b010d77260dba33dddbee343a47494b5335a3/vs_BuildTools.exe))
   - Minimum components: Desktop development with C++
-- FFmpeg: `winget install Gyan.FFmpeg`
 
 #### Linux (Ubuntu 24+)
 
 - CUDA ([download link](https://developer.nvidia.com/cuda-12-8-0-download-archive))
   - Minimum components: CUDA Development + CUDA Runtime
-- FFmpeg: `sudo apt install ffmpeg`
 - PortAudio runtime (for audio input): `sudo apt install libportaudio2`
 
 #### macOS
 
-- FFmpeg: `brew install ffmpeg`
 - Command Line Tools for Xcode: `xcode-select --install`
 
 On macOS and Windows, PortAudio ships inside the `sounddevice` wheel, so no extra install is needed for audio input.
@@ -111,9 +108,6 @@ The script requires a `.env` at the repo root with the crash report endpoint
 values (it fails fast without one). Copy `.env.example` and fill it in — see
 [tools/crash_endpoint/README.md](tools/crash_endpoint/README.md). Forks without
 their own endpoint can build with `--disable-crash-reporting` instead.
-
-ffmpeg/ffprobe are downloaded and bundled into the release automatically via
-`ffmpeg-downloader`.
 
 - **Windows / Linux:** output is the `dist/Autolume/` folder.
 - **macOS:** output is `dist/Autolume.app`, code-signed automatically — see

--- a/main.py
+++ b/main.py
@@ -27,29 +27,15 @@ from utils.user_data import init_data_root
 
 
 def get_runtime_bin_dir():
-    # PyInstaller frozen app: bundled ffmpeg/ffprobe/ninja live in _MEIPASS/bin
-    # (a subdir, to avoid colliding with same-named Python packages at the root).
+    # PyInstaller frozen app: the bundled ninja lives in _MEIPASS/bin.
     if IS_FROZEN:
         return os.path.join(sys._MEIPASS, "bin")
 
-    # Development mode
-    base = os.path.dirname(os.path.abspath(__file__))
-    bin_root = os.path.join(base, "bin")
-    for root, dirs, files in os.walk(bin_root):
-        if "ffmpeg.exe" in files:
-            return root
-    return bin_root
+    # Development mode: bin/ at the repository root, for any local tooling.
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "bin")
 
 BIN_DIR = get_runtime_bin_dir()
 os.environ["PATH"] = BIN_DIR + os.pathsep + os.environ.get("PATH", "")
-
-if IS_FROZEN:
-    # imageio-ffmpeg's own binary is pruned from the bundle (release.py);
-    # route it to the ffmpeg already shipped in bin/.
-    os.environ.setdefault(
-        "IMAGEIO_FFMPEG_EXE",
-        os.path.join(BIN_DIR, "ffmpeg.exe" if os.name == "nt" else "ffmpeg"),
-    )
 
 
 def main():

--- a/modules/preprocessing_module.py
+++ b/modules/preprocessing_module.py
@@ -1,9 +1,12 @@
 import logging
+import queue
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 import imgui
 from utils.gui_utils import imgui_utils
 import multiprocessing as mp
 
+from utils import video_io
 from utils.app_logging import LoggedProcess
 from widgets.native_browser_widget import NativeBrowserWidget
 from widgets.thumbnail_widget import ThumbnailWidget
@@ -16,6 +19,59 @@ resize_mode = ['stretch','center crop']
 padding_color = ['black', 'white', 'bleeding']
 
 logger = logging.getLogger(__name__)
+
+
+class _DurationProber:
+    """Probes video durations on worker threads.
+
+    Media I/O never runs on the render thread: a probe that stalls on a network
+    share or a corrupt file would freeze the UI (issue #62).
+    """
+
+    WORKERS = 2
+
+    def __init__(self):
+        self._executor = None
+        self._done = queue.Queue()   # (generation, path, duration)
+        self._generation = 0         # bumped when the pending set is discarded
+
+    def start(self, paths):
+        """Queue probes for ``paths``, discarding anything still in flight."""
+        self._generation += 1
+        if self._executor is None:
+            self._executor = ThreadPoolExecutor(max_workers=self.WORKERS,
+                                                thread_name_prefix='duration-probe')
+        for path in paths:
+            self._executor.submit(self._probe, path, self._generation)
+
+    def poll(self):
+        """Return {path: duration} for the probes that finished since last call."""
+        durations = {}
+        while True:
+            try:
+                generation, path, duration = self._done.get_nowait()
+            except queue.Empty:
+                return durations
+            if generation == self._generation:
+                durations[path] = duration
+
+    def cancel(self):
+        """Drop the results of any probe still in flight."""
+        self._generation += 1
+
+    def shutdown(self):
+        self.cancel()
+        if self._executor is not None:
+            self._executor.shutdown(wait=False, cancel_futures=True)
+            self._executor = None
+
+    def _probe(self, path, generation):
+        try:
+            duration = video_io.probe(path).duration
+        except video_io.VideoIOError as e:
+            logger.warning("Could not determine duration for video %s: %s", path, e)
+            duration = 0.0
+        self._done.put((generation, path, duration))
 
 class DataPreprocessing:
     """Data Preprocessing UI"""
@@ -40,10 +96,12 @@ class DataPreprocessing:
         # Video frame extraction
         self.fps = self.settings.fps
         self.video_durations = {}
+        self.duration_prober = _DurationProber()
+        self.last_video_count = None  # gates video thumbnail refreshes
         self.video_extraction_queue = mp.Queue()
         self.video_extraction_reply = mp.Queue()
         self.is_processing_video = False
-        
+
         self.min_res = 8
         self.max_res = 1024
         self.img_res = self.settings.size # current image resolution
@@ -166,19 +224,15 @@ class DataPreprocessing:
         if imgui.button("Import Videos", width=parameter_column_width, height=30):
             self.selected_video_files = self.data_browser.select_video_files()
             if self.selected_video_files:
-                # Reset cache variables when opening popup with new videos
-                if hasattr(self, 'last_video_count'):
-                    delattr(self, 'last_video_count')
-                if hasattr(self, 'last_fps'):
-                    delattr(self, 'last_fps')
-                if hasattr(self, 'last_expected_frames'):
-                    delattr(self, 'last_expected_frames')
-                self.video_durations = {}
+                self._reset_video_selection_state()
+                self.duration_prober.start(self.selected_video_files)
                 imgui.open_popup("Video Frame Extraction")
 
         # Video Frame Extraction Popup
         imgui.set_next_window_size(self.app.content_width // 2.5, self.app.content_height // 2.5, imgui.ONCE)
         if imgui.begin_popup_modal("Video Frame Extraction", flags=imgui.WINDOW_NO_SCROLLBAR)[0]:
+            self.video_durations.update(self.duration_prober.poll())
+
             popup_width = imgui.get_window_width()
             popup_height = imgui.get_window_height() - 50
 
@@ -251,7 +305,8 @@ class DataPreprocessing:
                             self.thumbnail_widget.update_thumbnails(self.imported_files)
 
                             # Reset variables
-                            self.selected_video_files = [] 
+                            self.selected_video_files = []
+                            self._reset_video_selection_state()
                             self.is_processing_video = False
                             self.loading_widget.hide()
                             self.fps = self.settings.fps 
@@ -273,14 +328,7 @@ class DataPreprocessing:
 
             if imgui_utils.button("Close", width=left_popup_width - 10, enabled=True):
                 self.selected_video_files = []
-                # Reset cache variables when closing popup
-                if hasattr(self, 'last_video_count'):
-                    delattr(self, 'last_video_count')
-                if hasattr(self, 'last_fps'):
-                    delattr(self, 'last_fps')
-                if hasattr(self, 'last_expected_frames'):
-                    delattr(self, 'last_expected_frames')
-                self.video_durations = {}
+                self._reset_video_selection_state()
                 imgui.close_current_popup()
             imgui.end_child()
 
@@ -300,7 +348,7 @@ class DataPreprocessing:
 
             if self.selected_video_files:
                 # Only update thumbnails if video list changed
-                if not hasattr(self, 'last_video_count') or len(self.selected_video_files) != self.last_video_count:
+                if len(self.selected_video_files) != self.last_video_count:
                     self.video_thumbnail_widget.update_thumbnails(self.selected_video_files)
                     self.last_video_count = len(self.selected_video_files)
 
@@ -311,21 +359,11 @@ class DataPreprocessing:
                 imgui.text("No videos selected.")
             
             imgui.end_child() # Thumbnail Video Scroll
-                        
-            # Only recalculate frames if FPS or video list changed
-            if (not hasattr(self, 'last_fps') or self.fps != self.last_fps or 
-                not hasattr(self, 'last_video_count') or len(self.selected_video_files) != self.last_video_count):
-                expected_frames = 0
-                for video_path in self.selected_video_files:
-                    if video_path not in self.video_durations:
-                        self.video_durations[video_path] = DatasetPreprocessingUtils.calculate_video_duration(video_path)
-                    duration = self.video_durations[video_path]
-                    expected_frames += int(duration * self.fps) if duration > 0 else 0
-                self.last_expected_frames = expected_frames
-                self.last_fps = self.fps
-                self.last_video_count = len(self.selected_video_files)
-            
-            imgui.text(f"Expected frames extracted: {getattr(self, 'last_expected_frames', 0)}")
+
+            durations = [self.video_durations.get(p) for p in self.selected_video_files]
+            expected_frames = sum(int(d * self.fps) for d in durations if d)
+            pending = " (calculating...)" if any(d is None for d in durations) else ""
+            imgui.text(f"Expected frames extracted: {expected_frames}{pending}")
 
             imgui.same_line(position=video_available_width - 50)
             if imgui.button("Remove"):
@@ -339,11 +377,7 @@ class DataPreprocessing:
 
                 self.video_thumbnail_widget.update_thumbnails(self.selected_video_files)
                 self.video_thumbnail_widget.clear_selected()
-
-                if hasattr(self, 'last_fps'):
-                    delattr(self, 'last_fps')
-                if hasattr(self, 'last_expected_frames'):
-                    delattr(self, 'last_expected_frames')
+                self.last_video_count = len(self.selected_video_files)
 
             imgui.end_child() # Video popup right
 
@@ -807,6 +841,12 @@ class DataPreprocessing:
         self.last_selected_file = None
     # ------------------------------
 
+    def _reset_video_selection_state(self):
+        """Drop probed durations and thumbnail state of the video popup."""
+        self.duration_prober.cancel()
+        self.video_durations = {}
+        self.last_video_count = None
+
     # ---Helper functions for preview updates
     def _get_settings_hash(self):
         """Create a hash of current settings for change detection."""
@@ -870,6 +910,8 @@ class DataPreprocessing:
         """Clean up multiprocessing resources before destroying the object"""
         try:
             self.reset_progress_variables()
+
+            self.duration_prober.shutdown()
 
             if hasattr(self, 'thumbnail_widget') and self.thumbnail_widget is not None:
                 self.thumbnail_widget.cleanup()

--- a/modules/visualizer.py
+++ b/modules/visualizer.py
@@ -14,6 +14,7 @@ import imgui
 import cv2
 
 import dnnlib
+from utils import video_io
 from utils.gui_utils import imgui_utils
 from utils.gui_utils import gl_utils
 from utils.gui_utils import text_utils
@@ -422,19 +423,30 @@ class Visualizer:
             self.recording_thread = None
 
     def _record_frames(self):
-        fourcc = cv2.VideoWriter_fourcc(*'mp4v')  # H.264 codec
-        out = None
-        while self.is_recording or not self.frame_queue.empty():
-            if not self.frame_queue.empty():
-                frame = self.frame_queue.get()
-                if out is None:
-                    height, width, channels = frame.shape
-                    os.makedirs(os.path.dirname(self.recording_file_path), exist_ok=True)
-                    out = cv2.VideoWriter(self.recording_file_path, fourcc, 30.0, (width, height))
-                out.write(frame)
-        if out is not None:
-            out.release()
-            logger.info("Recording saved to %s", self.recording_file_path)
+        writer = None
+        height = width = 0
+        try:
+            while self.is_recording or not self.frame_queue.empty():
+                if not self.frame_queue.empty():
+                    frame = self.frame_queue.get()
+                    if writer is None:
+                        # yuv420p needs even dimensions; crop any stray odd row/column
+                        height, width = frame.shape[0] & ~1, frame.shape[1] & ~1
+                        os.makedirs(os.path.dirname(self.recording_file_path), exist_ok=True)
+                        writer = video_io.VideoWriter(
+                            self.recording_file_path, width, height, fps=30,
+                            options={'preset': 'veryfast'})
+                    writer.write(frame[:height, :width])
+            if writer is not None:
+                writer.close()
+                logger.info("Recording saved to %s", self.recording_file_path)
+        except video_io.VideoIOError as e:
+            logger.error("Recording failed: %s", e)
+            if writer is not None:
+                try:
+                    writer.close()
+                except video_io.VideoIOError:
+                    pass
 
     def capture_screenshot(self, file_path):
         if 'image' in self.result:

--- a/projection/bayle_projection.py
+++ b/projection/bayle_projection.py
@@ -18,7 +18,6 @@ from time import perf_counter
 
 import multiprocessing as mp
 import clip
-import imageio
 
 logger = logging.getLogger(__name__)
 import numpy as np
@@ -29,6 +28,7 @@ import torch.nn.functional as F
 
 import dnnlib
 from torch_utils import legacy
+from utils import video_io
 from utils.device_utils import get_device
 
 import unicodedata
@@ -438,25 +438,27 @@ def run_projection(
     if save_video:
         logger.info('Generating optimization progress video...')
 
-        video = imageio.get_writer(f'{save_path}/proj.mp4', mode='I', fps=10, codec='libx264', bitrate='16M')
-        reply_queue.put([f'Saving optimization progress video "{save_path}/proj.mp4"', None, True, False])
-        for i, projected_w in enumerate(projected_w_steps):
-            halt = False
-            if not queue.empty():
-                halt = queue.get()
-                while not queue.empty():
+        width = G.img_resolution * (2 if target_fname else 1)
+        with video_io.VideoWriter(f'{save_path}/proj.mp4', width, G.img_resolution,
+                                  fps=10, bit_rate=16_000_000) as video:
+            reply_queue.put([f'Saving optimization progress video "{save_path}/proj.mp4"', None, True, False])
+            for i, projected_w in enumerate(projected_w_steps):
+                halt = False
+                if not queue.empty():
                     halt = queue.get()
-            if halt:
-                break
-            reply_queue.put([f'Generating frame {i}/{len(projected_w_steps)-1}...', None, True, False])
-            synth_image = G.synthesis(projected_w.unsqueeze(0), noise_mode='const')[0]
-            synth_image = (synth_image + 1) * (255/2)
-            synth_image = synth_image.permute(0, 2, 3, 1).clamp(0, 255).to(torch.uint8)[0].cpu().numpy()
-            if target_fname:
-                video.append_data(np.concatenate([target_uint8, synth_image], axis=1))
-            else:
-                video.append_data(synth_image)
-        video.close()
+                    while not queue.empty():
+                        halt = queue.get()
+                if halt:
+                    break
+                reply_queue.put([f'Generating frame {i}/{len(projected_w_steps)-1}...', None, True, False])
+                synth_image = G.synthesis(projected_w.unsqueeze(0), noise_mode='const')[0]
+                synth_image = (synth_image + 1) * (255/2)
+                synth_image = synth_image.permute(0, 2, 3, 1).clamp(0, 255).to(torch.uint8)[0].cpu().numpy()
+                if target_fname:
+                    frame = np.concatenate([target_uint8, synth_image], axis=1)
+                else:
+                    frame = synth_image
+                video.write(frame[:, :, ::-1])
         reply_queue.put(['Done Saving Video', None, True, True])
 
 #----------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,15 +5,12 @@ description = "Autolume is a no-coding generative AI system allowing artists to 
 readme = "README.md"
 requires-python = "==3.12.*"
 dependencies = [
+    "av>=18.1,<19",
     "click>=8.1.8",
     "codecarbon>=3.2.6",
     "fbpca==1.0",
-    "ffmpeg-downloader>=0.5.2",
-    "ffmpeg-python==0.2.0",
     "filedialpy==1.3.4",
     "glfw>=2.8.0",
-    "imageio-ffmpeg==0.4.9",
-    "imageio==2.31.5",
     "imgui==1.4.1",
     "kmeans-pytorch==0.3",
     "kornia==0.7.0",

--- a/release.py
+++ b/release.py
@@ -22,8 +22,8 @@ right PyInstaller invocation:
   store-credentials``). It can be combined with ``--package`` or run alone
   against an already-built ``.dmg``.
 
-ffmpeg/ffprobe are bundled on every platform via ffmpeg-downloader so the
-artifact is self-contained (Windows uses gyan.dev's essentials build).
+Video I/O needs no external binary: the PyAV wheel carries its own FFmpeg
+libraries, which PyInstaller collects with the package.
 
 Pass ``--package`` to additionally wrap the build into the platform's
 distributable format: ``.AppImage`` (zstd) on Linux, ``.dmg`` (lzma) on macOS,
@@ -54,8 +54,6 @@ import tarfile
 import tempfile
 import urllib.request
 from pathlib import Path
-
-import ffmpeg_downloader as ffdl
 
 from utils.resource_paths import get_version
 
@@ -110,39 +108,6 @@ def package_dir(name: str) -> Path:
 def spec_arg(src: Path, dest: str) -> str:
     """Build a PyInstaller add-data/add-binary value using the host separator."""
     return f"{src}{os.pathsep}{dest}"
-
-
-# Windows bundles gyan.dev's "essentials" ffmpeg (~97 MB/exe vs ~136 MB for
-# the default full build); libx264 + aac is all Autolume uses. The major
-# version is pinned because "release@essentials" resolves the latest version
-# across all providers, usually a btbn post-release with no essentials build.
-FFMPEG_WIN_SPEC = "8@essentials"
-
-
-def ensure_ffmpeg() -> tuple[Path, Path]:
-    """Make sure ffmpeg + ffprobe are downloaded and return their paths."""
-    if IS_WINDOWS and ffdl.installed():
-        banner = subprocess.run(
-            [ffdl.ffmpeg_path, "-version"], capture_output=True, text=True
-        ).stdout.partition("\n")[0]
-        if "essentials_build" not in banner:
-            print(f"Cached ffmpeg is not the essentials build ({banner}); replacing...")
-            subprocess.run(
-                [sys.executable, "-m", "ffmpeg_downloader", "uninstall", "-y"], check=True
-            )
-    if not ffdl.installed():
-        print("Installing ffmpeg via ffmpeg-downloader...")
-        cmd = [sys.executable, "-m", "ffmpeg_downloader", "install", "-y"]
-        if IS_WINDOWS:
-            cmd.append(FFMPEG_WIN_SPEC)
-        else:
-            cmd.append("--no-simlinks")  # don't touch the user's ~/.local/bin
-        subprocess.run(cmd, check=True)
-    ffmpeg = ffdl.ffmpeg_path and Path(ffdl.ffmpeg_path)
-    ffprobe = ffdl.ffprobe_path and Path(ffdl.ffprobe_path)
-    if not ffmpeg or not ffmpeg.exists() or not ffprobe or not ffprobe.exists():
-        fail("ffmpeg/ffprobe not found after install; run `uv run ffdl install` manually")
-    return ffmpeg, ffprobe
 
 
 def bake_crash_endpoint() -> str:
@@ -295,14 +260,7 @@ def build_args(disable_crash_reporting: bool = False) -> tuple[list[str], str | 
             ]
 
     # --- Binaries shipped on every platform -------------------------------
-    # ffmpeg/ffprobe (and ninja below) go in a bin/ subdir, not the bundle root:
-    # on macOS/Linux the extensionless `ffmpeg` binary would otherwise collide
-    # with the `ffmpeg` (ffmpeg-python) package PyInstaller packs at the root.
-    # main.py adds this bin/ dir to PATH at runtime.
-    ffmpeg, ffprobe = ensure_ffmpeg()
-    binaries = [
-        (ffmpeg, "bin"), (ffprobe, "bin"), *glfw_native_libs(), *sounddevice_native_libs(),
-    ]
+    binaries = [*glfw_native_libs(), *sounddevice_native_libs()]
 
     # --- Data files shipped on every platform -----------------------------
     clip = package_dir("clip")
@@ -327,7 +285,9 @@ def build_args(disable_crash_reporting: bool = False) -> tuple[list[str], str | 
     if NEEDS_JIT_TOOLCHAIN:
         datas.append((PRECOMPILED_OPS_DIR, "torch_extensions"))
 
-        binaries.append((ninja_binary(), "bin"))  # same collision risk as ffmpeg
+        # ninja goes in a bin/ subdir rather than the bundle root; main.py
+        # prepends that dir to PATH so the JIT fallback finds it.
+        binaries.append((ninja_binary(), "bin"))
 
         torch_lib = package_dir("torch") / "lib"
         if IS_WINDOWS:
@@ -430,9 +390,6 @@ PRUNE_PATTERNS = [
     # Multi-GPU cusolver backend (150 MB); torch_cuda.dll does not import it
     # and nothing in Autolume reaches the cusolverMg APIs.
     "_internal/torch/lib/cusolverMg64_*.dll",
-    # imageio-ffmpeg's own ffmpeg (62 MB); main.py points IMAGEIO_FFMPEG_EXE
-    # at the ffmpeg already shipped in bin/.
-    "_internal/imageio_ffmpeg/binaries/ffmpeg-*",
     # cuRAND (69 MB); nothing in the bundle references it, torch uses its own
     # Philox RNG on CUDA. Verified by training + inference with it removed.
     "_internal/torch/lib/curand64_*.dll",

--- a/release.py
+++ b/release.py
@@ -400,6 +400,11 @@ PRUNE_PATTERNS = [
     # Alternate nvrtc build (83 MB); nothing references it and the primary
     # nvrtc ships alongside.
     "_internal/torch/lib/nvrtc64_*.alt.dll",
+    # OpenCV's private FFmpeg backend (25 MB), loaded lazily and only by
+    # cv2.VideoCapture/VideoWriter; all video I/O goes through PyAV and no
+    # call site remains (cv2 does image ops only). Verified by thumbnail
+    # rendering + dataset build with it removed.
+    "_internal/cv2/opencv_videoio_ffmpeg*.dll",
 ]
 
 

--- a/super_res/super_res.py
+++ b/super_res/super_res.py
@@ -5,12 +5,11 @@ import numpy as np
 import torchvision.transforms.functional as F
 import os
 import argparse
-import ffmpeg
 import cv2
 from torchvision import transforms
 from super_res.net_base import SRVGGNetPlus, SRVGGNetCompact, RRDBNet
 from utils.device_utils import get_device
-from utils import device_utils
+from utils import device_utils, video_io
 from utils.resource_paths import resource_path
 from utils.user_data import cache_path
 from utils.downloads import download_file
@@ -90,77 +89,11 @@ def check_width_height(args):
   return args.out_width is not None and args.out_height is not None
 
 
-def get_resolution(video_path):
-  probe = ffmpeg.probe(video_path)
-  video_streams = [stream for stream in probe['streams'] if stream['codec_type'] == 'video']
-  w = video_streams[0]['width']
-  h = video_streams[0]['height']
-  return w,h
-
-def get_audio(video_path):
-  probe = ffmpeg.probe(video_path)
-  has_audio = any(stream['codec_type'] == 'audio' for stream in probe['streams'])
-  audio=ffmpeg.input(video_path).audio if has_audio else None
-  return audio
-
-class Reader:
-    def __init__(self, width, height, video_path):
-      self.width=width
-      self.height=height
-      self.stream_reader = (
-                ffmpeg.input(video_path).output('pipe:', format='rawvideo', pix_fmt='bgr24',
-                                                loglevel='error').run_async(
-                                                    pipe_stdin=True, pipe_stdout=True))
-    def get_frame_from_stream(self):
-        img_bytes = self.stream_reader.stdout.read(self.width * self.height * 3)  # 3 bytes for one pixel
-        if not img_bytes:
-            return None
-        img = np.frombuffer(img_bytes, np.uint8).reshape([self.height, self.width, 3])
-        return img
-
-    def get_frame(self):
-        return self.get_frame_from_stream()
-
-class Writer:
-
-    def __init__(self, args, audio, height, width, video_save_path, fps):
-        logger.info("Saving video to %s", video_save_path)
-        if args.scale_mode:
-          out_width, out_height = int(width * args.outscale), int(height * args.outscale)
-        else:
-          assert (args.out_width is not None and args.out_height is not None) # width and height should be specify together
-
-          out_width, out_height = int(args.out_width), int(args.out_width)
-
-        if audio is not None:
-            self.stream_writer = (
-                ffmpeg.input('pipe:', format='rawvideo', pix_fmt='bgr24', s=f'{out_width}x{out_height}',
-                             framerate=fps).output(
-                                 audio,
-                                 video_save_path,
-                                 pix_fmt='yuv420p',
-                                 vcodec='libx264',
-                                 loglevel='error',
-                                 acodec='copy').overwrite_output().run_async(
-                                     pipe_stdin=True, pipe_stdout=True,cmd='ffmpeg'))
-        else:
-            self.stream_writer = (
-                ffmpeg.input('pipe:', format='rawvideo',
-                pix_fmt='bgr24',
-                s=f'{out_width}x{out_height}',
-                             framerate=fps).output(
-                                 video_save_path, pix_fmt='yuv420p',vcodec='libx264',
-                                 loglevel='error').overwrite_output().run_async(
-                                     pipe_stdin=True, pipe_stdout=True,cmd='ffmpeg'))
-
-    def write_frame(self, frame):
-        frame = frame.tobytes()
-        self.stream_writer.stdin.write(frame)
-
-    def close(self):
-        self.stream_writer.stdin.close()
-        self.stream_writer.wait()
-
+def output_size(args, width, height):
+  if args.scale_mode:
+    return int(width * args.outscale), int(height * args.outscale)
+  assert check_width_height(args)  # width and height should be specified together
+  return int(args.out_width), int(args.out_height)
 
 
 def base_args():
@@ -185,33 +118,29 @@ def process(args,file):
   upsampler=load_model(args.model_type,model_path)
   head, tail = os.path.split(file)
   if file[-3:] == 'mp4' or file[-3:] == 'avi' or file[-3:] == 'mov':
-    width, height = get_resolution(file)
+    info = video_io.probe(file)
+    width, height = info.width, info.height
 
     if args.outscale > 4 or (check_width_height(args) and (args.out_width > 4*width or args.out_height > 4*height)):
       logger.warning('Super-res scale larger than x4 requires non-model inference with interpolation and can be slower')
 
-
-    audio = get_audio(file)
+    out_width, out_height = output_size(args, width, height)
     if args.scale_mode:
       video_save_path = os.path.join(args.result_path, tail[
-                                                         :-4] + f'_result_{args.model_type}_{int(width * args.outscale)}x{int(height * args.outscale)}_Sharpness{args.sharpen_scale}.mp4')
+                                                         :-4] + f'_result_{args.model_type}_{out_width}x{out_height}_Sharpness{args.sharpen_scale}.mp4')
     else:
       video_save_path = os.path.join(args.result_path, tail[
-                                                         :-4] + f'_result_{args.model_type}_x{int(args.out_width)}x{int(args.out_height)}_Sharpness{args.sharpen_scale}.mp4')
+                                                         :-4] + f'_result_{args.model_type}_x{out_width}x{out_height}_Sharpness{args.sharpen_scale}.mp4')
 
-    cap = cv2.VideoCapture(file)
-    frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    frame_count = int(info.duration * info.fps)
     logger.debug("Frame count: %d", frame_count)
     pbar = tqdm(total=frame_count, unit='frame', desc='inference', disable=None)
 
-    fps = cap.get(cv2.CAP_PROP_FPS)
-
-    reader= Reader(width,height,file)
-    writer = Writer(args, audio, height, width, video_save_path, fps=fps)
-
-    while True:
-      img = reader.get_frame()
-      if img is not None:
+    logger.info("Saving video to %s", video_save_path)
+    with video_io.VideoReader(file) as reader, video_io.VideoWriter(
+        video_save_path, out_width, out_height, info.fps,
+        audio_from=file if info.has_audio else None) as writer:
+      for img in reader.frames():
         input=torch.tensor(img).permute(2,0,1).float().to(get_device())/255
         input=torch.unsqueeze(input,0).to(next(upsampler.parameters()).dtype)
         with torch.inference_mode():
@@ -219,32 +148,15 @@ def process(args,file):
           output=F.adjust_sharpness(output,args.sharpen_scale)*255
 
           output = output[0].permute(1,2,0).cpu().numpy().astype(np.uint8)
-        
+
           if args.scale_mode:
             if args.outscale != 4:
-              output = cv2.resize(
-                output, (
-                    int(width * args.outscale),
-                    int(height * args.outscale),
-                ), interpolation=cv2.INTER_LINEAR)
-
-
+              output = cv2.resize(output, (out_width, out_height), interpolation=cv2.INTER_LINEAR)
           else:
-            output = cv2.resize(
-                output, (
-                    int(args.out_width),
-                    int(args.out_height),
-                ), interpolation=cv2.INTER_LINEAR)
+            output = cv2.resize(output, (out_width, out_height), interpolation=cv2.INTER_LINEAR)
 
-      
-        writer.write_frame(output)
+        writer.write(output)
         pbar.update(1)
-        ret, img = cap.read()
-
-      else:
-        break
-
-    writer.close()
 
   elif file[-3:] == 'jpg' or file[-3:] == 'png':
     data_transformer = transforms.Compose([transforms.ToTensor()])
@@ -314,46 +226,33 @@ def _sr_image(model, args, file, tail, file_idx, reply_queue):
 
 
 def _sr_video(model, args, file, tail, file_idx, reply_queue):
-    audio = get_audio(file)
-    video = cv2.VideoCapture(file)
-    fps = video.get(cv2.CAP_PROP_FPS)
-    total_frames = int(video.get(cv2.CAP_PROP_FRAME_COUNT))
-    video_width = int(video.get(cv2.CAP_PROP_FRAME_WIDTH))
-    video_height = int(video.get(cv2.CAP_PROP_FRAME_HEIGHT))
-    video.release()
-    if args.scale_mode:
-        video_save_path = os.path.join(args.result_path, tail[:-4] + f'_result_{args.model_type}_{int(video_width * args.outscale)}x{int(video_height * args.outscale)}_Sharpness{args.sharpen_scale}.mp4')
-    else:
-        video_save_path = os.path.join(args.result_path, tail[:-4] + f'_result_{args.model_type}_{int(args.out_width)}x{int(args.out_height)}_Sharpness{args.sharpen_scale}.mp4')
+    info = video_io.probe(file)
+    total_frames = int(info.duration * info.fps)
+    out_width, out_height = output_size(args, info.width, info.height)
+    video_save_path = os.path.join(args.result_path, tail[:-4] + f'_result_{args.model_type}_{out_width}x{out_height}_Sharpness{args.sharpen_scale}.mp4')
     logger.info("Saving video to %s", video_save_path)
-    writer = Writer(args, audio, video_height, video_width, video_save_path=video_save_path, fps=fps)
-    reader = Reader(video_width, video_height, file)
     model_dtype = next(model.parameters()).dtype
     start_time = time.time()
     last_put = start_time
     super_res_idx = 0
     reply_queue.put([file_idx, super_res_idx, total_frames, -1, False])
-    while True:
-        img = reader.get_frame()
-        if img is None:
-            break
-        with torch.inference_mode():
-            sr_input = (torch.tensor(img).permute(2, 0, 1).unsqueeze(0).float().to(get_device()) / 255).to(model_dtype)
-            sr_output = model(sr_input).float()
-            sr_output = F.adjust_sharpness(sr_output, args.sharpen_scale) * 255
-            sr_output = sr_output[0].permute(1, 2, 0).cpu().numpy().astype(np.uint8)
-            if args.scale_mode:
-                sr_output = cv2.resize(sr_output, (int(video_width * args.outscale), int(video_height * args.outscale)), interpolation=cv2.INTER_LINEAR)
-            else:
-                sr_output = cv2.resize(sr_output, (int(args.out_width), int(args.out_height)), interpolation=cv2.INTER_LINEAR)
-            writer.write_frame(sr_output)
-        super_res_idx += 1
-        now = time.time()
-        if now - last_put >= 0.15 or super_res_idx >= total_frames:
-            eta = (now - start_time) / super_res_idx * max(total_frames - super_res_idx, 0)
-            reply_queue.put([file_idx, super_res_idx, total_frames, eta, False])
-            last_put = now
-    writer.close()
+    with video_io.VideoReader(file) as reader, video_io.VideoWriter(
+            video_save_path, out_width, out_height, info.fps,
+            audio_from=file if info.has_audio else None) as writer:
+        for img in reader.frames():
+            with torch.inference_mode():
+                sr_input = (torch.tensor(img).permute(2, 0, 1).unsqueeze(0).float().to(get_device()) / 255).to(model_dtype)
+                sr_output = model(sr_input).float()
+                sr_output = F.adjust_sharpness(sr_output, args.sharpen_scale) * 255
+                sr_output = sr_output[0].permute(1, 2, 0).cpu().numpy().astype(np.uint8)
+                sr_output = cv2.resize(sr_output, (out_width, out_height), interpolation=cv2.INTER_LINEAR)
+                writer.write(sr_output)
+            super_res_idx += 1
+            now = time.time()
+            if now - last_put >= 0.15 or super_res_idx >= total_frames:
+                eta = (now - start_time) / super_res_idx * max(total_frames - super_res_idx, 0)
+                reply_queue.put([file_idx, super_res_idx, total_frames, eta, False])
+                last_put = now
 
 
 def run_super_res(queue, reply_queue):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+"""Shared test setup.
+
+CI runs headless, where PyOpenGL cannot bind a GL library; importing any
+widget module (they pull in utils.gui_utils.gl_utils) would then fail at
+collection. The widget tests only exercise GL-free logic, so when the real
+binding is unavailable a permissive stub is installed before the test
+modules import.
+"""
+import sys
+import types
+
+try:
+    import OpenGL.GL  # noqa: F401
+except Exception:
+    class _StubModule(types.ModuleType):
+        """OpenGL stand-in: GL_* constants are ints, functions are no-ops."""
+        def __getattr__(self, name):
+            if name.startswith('__'):
+                raise AttributeError(name)
+            if name.isupper():
+                return 0
+            return lambda *args, **kwargs: None
+
+    def _install(name):
+        module = _StubModule(name)
+        sys.modules[name] = module
+        parent, _, child = name.rpartition('.')
+        if parent:
+            setattr(sys.modules[parent], child, module)
+
+    for _name in ('OpenGL', 'OpenGL.GL', 'OpenGL.GL.ARB',
+                  'OpenGL.GL.ARB.texture_float', 'OpenGL.EGL'):
+        _install(_name)

--- a/tests/test_opengl_support.py
+++ b/tests/test_opengl_support.py
@@ -1,4 +1,5 @@
 import ctypes
+import importlib
 import sys
 import types
 
@@ -30,6 +31,10 @@ def gl_stub(monkeypatch):
             glGetString=lambda name: {"version": version,
                                       "renderer": renderer}[name])
         monkeypatch.setitem(sys.modules, "OpenGL.GL", stub)
+        # ``import OpenGL.GL as gl`` binds the package attribute when the real
+        # module has already been imported, bypassing the sys.modules entry.
+        monkeypatch.setattr(importlib.import_module("OpenGL"), "GL", stub,
+                            raising=False)
     return install
 
 

--- a/tests/test_preprocessing_video.py
+++ b/tests/test_preprocessing_video.py
@@ -149,7 +149,12 @@ def test_extract_videos_cancels_mid_video(tmp_path):
     source = make_video(tmp_path / 'clip.mp4', seconds=3)
 
     class CancelAfter:
-        """queue_in stand-in that answers "cancel" once probed often enough."""
+        """queue_in stand-in that answers "cancel" once probed often enough.
+
+        Counting empty() calls couples this to how often extract_videos polls
+        for cancellation (currently once per decoded frame); if that cadence
+        is ever throttled, adjust the probe budget rather than the design.
+        """
 
         def __init__(self, probes):
             self.probes = probes

--- a/tests/test_preprocessing_video.py
+++ b/tests/test_preprocessing_video.py
@@ -1,0 +1,168 @@
+"""Tests for the dataset preprocessing video path: duration probing and extraction."""
+import queue
+import threading
+import time
+
+import numpy as np
+import pytest
+
+from modules.preprocessing_module import _DurationProber
+from utils import video_io
+from utils.dataset_preprocessing_utils import DatasetPreprocessingUtils
+from utils.video_io import MediaInfo, VideoIOError, VideoWriter
+
+WIDTH, HEIGHT = 64, 48
+SOURCE_FPS = 20
+
+
+def make_video(path, seconds=2):
+    """Synthesize a small mp4 and return its path as a string."""
+    with VideoWriter(str(path), WIDTH, HEIGHT, SOURCE_FPS) as writer:
+        for i in range(seconds * SOURCE_FPS):
+            frame = np.full((HEIGHT, WIDTH, 3), i * 7 % 256, dtype=np.uint8)
+            writer.write(frame)
+    return str(path)
+
+
+def run_extraction(paths, fps, queue_in=None):
+    """Run extract_videos synchronously and return the emitted messages."""
+    queue_out = queue.Queue()
+    DatasetPreprocessingUtils.extract_videos(paths, fps, queue_in or queue.Queue(), queue_out)
+    messages = []
+    while not queue_out.empty():
+        messages.append(queue_out.get_nowait())
+    return messages
+
+
+def info(duration):
+    return MediaInfo(duration=duration, width=WIDTH, height=HEIGHT, fps=SOURCE_FPS,
+                     has_audio=False)
+
+
+@pytest.fixture
+def prober():
+    instance = _DurationProber()
+    yield instance
+    instance.shutdown()
+
+
+def collect(prober, expected, timeout=10.0):
+    """Poll until ``expected`` durations arrived or the timeout expires."""
+    deadline = time.monotonic() + timeout
+    durations = {}
+    while len(durations) < expected and time.monotonic() < deadline:
+        durations.update(prober.poll())
+        time.sleep(0.01)
+    return durations
+
+
+# --- Duration prober ---------------------------------------------------------
+
+def test_prober_delivers_durations(monkeypatch, prober):
+    monkeypatch.setattr(video_io, 'probe', lambda path: info(len(path)))
+
+    prober.start(['a.mp4', 'bb.mp4'])
+
+    assert collect(prober, 2) == {'a.mp4': 5.0, 'bb.mp4': 6.0}
+
+
+def test_prober_poll_is_empty_without_work(prober):
+    assert prober.poll() == {}
+
+
+def test_prober_failed_probe_yields_zero(monkeypatch, prober):
+    def failing(path):
+        raise VideoIOError(f'Cannot open "{path}"')
+
+    monkeypatch.setattr(video_io, 'probe', failing)
+    prober.start(['broken.mp4'])
+
+    assert collect(prober, 1) == {'broken.mp4': 0.0}
+
+
+def test_prober_cancel_discards_stale_results(monkeypatch, prober):
+    released = threading.Event()
+
+    def blocking(path):
+        released.wait(10)
+        return info(1.0)
+
+    monkeypatch.setattr(video_io, 'probe', blocking)
+    prober.start(['stale.mp4'])
+    prober.cancel()
+    released.set()
+
+    assert collect(prober, 1, timeout=1.0) == {}
+
+
+def test_prober_restart_delivers_only_the_new_generation(monkeypatch, prober):
+    monkeypatch.setattr(video_io, 'probe', lambda path: info(3.0))
+
+    prober.start(['old.mp4'])
+    prober.cancel()
+    prober.start(['new.mp4'])
+
+    assert collect(prober, 1) == {'new.mp4': 3.0}
+
+
+# --- Frame extraction --------------------------------------------------------
+
+def test_extract_videos_writes_named_frames(tmp_path):
+    source = make_video(tmp_path / 'clip.mp4')
+
+    messages = run_extraction([source], 5)
+
+    out_dir = tmp_path / 'clip_frames @ 5 fps'
+    names = sorted(p.name for p in out_dir.iterdir())
+    assert names[0] == 'clip_frame_00001.jpg'
+    assert len(names) == 10
+    assert messages[-1] == {'type': 'completed', 'results': [str(out_dir)]}
+
+
+def test_extract_videos_reports_monotonic_progress(tmp_path):
+    sources = [make_video(tmp_path / 'one.mp4'), make_video(tmp_path / 'two.mp4')]
+
+    messages = run_extraction(sources, 10)
+
+    progress = [m for m in messages if m['type'] == 'progress']
+    percentages = [m['percentage'] for m in progress]
+    assert percentages == sorted(percentages)
+    assert percentages[0] == 0.0
+    assert percentages[-1] == pytest.approx(100.0, abs=1.0)
+    assert all(m['total'] == 2 for m in progress)
+    assert {m['current_file'] for m in progress} == {'one.mp4', 'two.mp4'}
+    assert progress[-1]['current'] == 1
+
+
+def test_extract_videos_skips_undecodable_video(tmp_path):
+    junk = tmp_path / 'junk.mp4'
+    junk.write_bytes(b'not a video at all' * 64)
+    source = make_video(tmp_path / 'good.mp4')
+
+    messages = run_extraction([str(junk), source], 5)
+
+    assert messages[-1] == {'type': 'completed',
+                            'results': [str(tmp_path / 'good_frames @ 5 fps')]}
+
+
+def test_extract_videos_cancels_mid_video(tmp_path):
+    source = make_video(tmp_path / 'clip.mp4', seconds=3)
+
+    class CancelAfter:
+        """queue_in stand-in that answers "cancel" once probed often enough."""
+
+        def __init__(self, probes):
+            self.probes = probes
+
+        def empty(self):
+            self.probes -= 1
+            return self.probes > 0
+
+        def get_nowait(self):
+            return 'cancel'
+
+    messages = run_extraction([source], 20, queue_in=CancelAfter(10))
+
+    written = list((tmp_path / 'clip_frames @ 20 fps').iterdir())
+    assert 0 < len(written) < 60
+    assert all(m['type'] == 'progress' for m in messages)

--- a/tests/test_thumbnail_widget.py
+++ b/tests/test_thumbnail_widget.py
@@ -1,0 +1,31 @@
+"""Tests for the headless thumbnail decode path of widgets.thumbnail_widget."""
+import numpy as np
+import pytest
+
+from utils.video_io import VideoWriter
+from widgets.thumbnail_widget import _render_thumbnail
+
+WIDTH, HEIGHT = 64, 48
+SIZE = 32
+
+
+@pytest.fixture
+def video(tmp_path):
+    path = tmp_path / 'clip.mp4'
+    with VideoWriter(path, WIDTH, HEIGHT, fps=10) as writer:
+        for i in range(5):
+            frame = np.full((HEIGHT, WIDTH, 3), i * 20, dtype=np.uint8)
+            writer.write(frame)
+    return str(path)
+
+
+def test_render_thumbnail_video(video):
+    thumbnail = _render_thumbnail(video, SIZE, padding=0)
+    assert thumbnail.shape == (SIZE, SIZE, 3)
+    assert thumbnail.dtype == np.uint8
+
+
+def test_render_thumbnail_unreadable_video(tmp_path):
+    path = tmp_path / 'junk.mp4'
+    path.write_bytes(b'not a video, just some bytes' * 64)
+    assert _render_thumbnail(str(path), SIZE, padding=0) is None

--- a/tests/test_video_io.py
+++ b/tests/test_video_io.py
@@ -138,6 +138,12 @@ def test_video_reader_yields_bgr_frames(video):
 
     assert len(frames) == 30
     assert all(f.shape == (HEIGHT, WIDTH, 3) and f.dtype == np.uint8 for f in frames)
+    # gradient() ramps red along x and holds blue constant; in bgr24 the ramp
+    # must land on channel 2 — a silent RGB/BGR swap would corrupt every
+    # consumer's colors while passing shape checks.
+    first = frames[0]
+    assert int(first[0, -1, 2]) - int(first[0, 0, 2]) > 200
+    assert abs(int(first[0, -1, 0]) - int(first[0, 0, 0])) < 30
 
 
 def test_video_reader_rejects_non_video(junk):
@@ -158,7 +164,10 @@ def test_video_writer_roundtrip(tmp_path):
     assert info.has_audio is False
 
     with VideoReader(str(out)) as reader:
-        assert len(list(reader.frames())) == 30
+        frames = list(reader.frames())
+    assert len(frames) == 30
+    # the red x-ramp written on bgr channel 2 must come back on channel 2
+    assert int(frames[0][0, -1, 2]) - int(frames[0][0, 0, 2]) > 200
 
 
 def test_video_writer_copies_audio(tmp_path):
@@ -169,7 +178,11 @@ def test_video_writer_copies_audio(tmp_path):
         for i in range(30):
             writer.write(gradient(i)[:, :, ::-1])
 
-    assert probe(str(out)).has_audio is True
+    info = probe(str(out))
+    assert info.has_audio is True
+    # the source carries 1.0s of audio; a bug dropping most packets would
+    # still report has_audio, but not the full duration
+    assert info.duration == pytest.approx(1.0, abs=0.2)
 
 
 def test_video_writer_ignores_silent_audio_source(tmp_path, video):

--- a/tests/test_video_io.py
+++ b/tests/test_video_io.py
@@ -1,0 +1,205 @@
+"""Tests for utils.video_io, run against fixtures synthesized with PyAV."""
+import av
+import numpy as np
+import pytest
+
+from utils.video_io import (MediaInfo, VideoIOError, VideoReader, VideoWriter,
+                            extract_frames, first_frame, probe)
+
+WIDTH, HEIGHT = 64, 48
+SAMPLE_RATE = 48000
+
+
+def gradient(index, width=WIDTH, height=HEIGHT):
+    """Deterministic rgb24 test pattern that changes with the frame index."""
+    x = np.linspace(0, 255, width, dtype=np.uint8)
+    y = np.linspace(0, 255, height, dtype=np.uint8)
+    image = np.zeros((height, width, 3), dtype=np.uint8)
+    image[:, :, 0] = x[None, :]
+    image[:, :, 1] = y[:, None]
+    image[:, :, 2] = index * 7 % 256
+    return image
+
+
+def make_video(path, frames=30, fps=30, width=WIDTH, height=HEIGHT, with_audio=False):
+    with av.open(str(path), mode='w') as container:
+        video = container.add_stream('libx264', rate=fps)
+        video.width = width
+        video.height = height
+        video.pix_fmt = 'yuv420p'
+        audio = container.add_stream('aac', rate=SAMPLE_RATE) if with_audio else None
+
+        for i in range(frames):
+            frame = av.VideoFrame.from_ndarray(gradient(i, width, height), format='rgb24')
+            for packet in video.encode(frame):
+                container.mux(packet)
+        for packet in video.encode():
+            container.mux(packet)
+
+        if audio is not None:
+            count = int(SAMPLE_RATE * frames / fps)
+            t = np.arange(count) / SAMPLE_RATE
+            samples = (np.sin(2 * np.pi * 440 * t) * 16000).astype(np.int16).reshape(1, -1)
+            frame = av.AudioFrame.from_ndarray(samples, format='s16', layout='mono')
+            frame.sample_rate = SAMPLE_RATE
+            for packet in audio.encode(frame):
+                container.mux(packet)
+            for packet in audio.encode():
+                container.mux(packet)
+    return str(path)
+
+
+@pytest.fixture
+def video(tmp_path):
+    return make_video(tmp_path / 'clip.mp4')
+
+
+@pytest.fixture
+def junk(tmp_path):
+    path = tmp_path / 'junk.mp4'
+    path.write_bytes(b'not a video, just some bytes' * 64)
+    return str(path)
+
+
+def test_probe_reports_stream_properties(video):
+    info = probe(video)
+    assert isinstance(info, MediaInfo)
+    assert (info.width, info.height) == (WIDTH, HEIGHT)
+    assert info.fps == pytest.approx(30.0)
+    assert info.duration == pytest.approx(1.0, abs=0.1)
+    assert info.has_audio is False
+
+
+def test_probe_detects_audio(tmp_path):
+    path = make_video(tmp_path / 'with_audio.mp4', with_audio=True)
+    assert probe(path).has_audio is True
+
+
+def test_probe_missing_file_raises_with_path(tmp_path):
+    missing = str(tmp_path / 'nope.mp4')
+    with pytest.raises(VideoIOError) as excinfo:
+        probe(missing)
+    assert missing in str(excinfo.value)
+
+
+def test_probe_non_video_raises(junk):
+    with pytest.raises(VideoIOError):
+        probe(junk)
+
+
+def test_extract_frames_count_and_naming(tmp_path):
+    path = make_video(tmp_path / 'two_seconds.mp4', frames=60, fps=30)
+    out_dir = tmp_path / 'frames'
+
+    written = extract_frames(path, 10, str(out_dir), 'clip')
+
+    assert written == 20
+    names = sorted(p.name for p in out_dir.iterdir())
+    assert names[0] == 'clip_frame_00001.jpg'
+    assert names[-1] == 'clip_frame_00020.jpg'
+    assert len(names) == 20
+
+
+def test_extract_frames_upsamples_slow_source(tmp_path):
+    path = make_video(tmp_path / 'slow.mp4', frames=10, fps=5)
+    out_dir = tmp_path / 'frames'
+
+    written = extract_frames(path, 10, str(out_dir), 'slow')
+
+    assert written == 20
+    assert len(list(out_dir.iterdir())) == 20
+
+
+def test_extract_frames_reports_progress(tmp_path, video):
+    seen = []
+    written = extract_frames(video, 10, str(tmp_path / 'out'), 'clip',
+                             on_progress=seen.append)
+
+    assert seen == list(range(1, written + 1))
+
+
+def test_extract_frames_cancels_early(tmp_path):
+    path = make_video(tmp_path / 'long.mp4', frames=90, fps=30)
+    out_dir = tmp_path / 'out'
+    seen = []
+
+    written = extract_frames(path, 30, str(out_dir), 'long',
+                             on_progress=seen.append,
+                             should_cancel=lambda: len(seen) >= 5)
+
+    assert 5 <= written < 90
+    assert len(list(out_dir.iterdir())) == written
+
+
+def test_video_reader_yields_bgr_frames(video):
+    with VideoReader(video) as reader:
+        assert reader.info.width == WIDTH
+        frames = list(reader.frames())
+
+    assert len(frames) == 30
+    assert all(f.shape == (HEIGHT, WIDTH, 3) and f.dtype == np.uint8 for f in frames)
+
+
+def test_video_reader_rejects_non_video(junk):
+    with pytest.raises(VideoIOError):
+        VideoReader(junk)
+
+
+def test_video_writer_roundtrip(tmp_path):
+    out = tmp_path / 'written.mp4'
+    with VideoWriter(str(out), WIDTH, HEIGHT, 15) as writer:
+        for i in range(30):
+            writer.write(gradient(i)[:, :, ::-1])
+
+    info = probe(str(out))
+    assert (info.width, info.height) == (WIDTH, HEIGHT)
+    assert info.fps == pytest.approx(15.0)
+    assert info.duration == pytest.approx(2.0, abs=0.2)
+    assert info.has_audio is False
+
+    with VideoReader(str(out)) as reader:
+        assert len(list(reader.frames())) == 30
+
+
+def test_video_writer_copies_audio(tmp_path):
+    source = make_video(tmp_path / 'source.mp4', with_audio=True)
+    out = tmp_path / 'with_audio.mp4'
+
+    with VideoWriter(str(out), WIDTH, HEIGHT, 30, audio_from=source) as writer:
+        for i in range(30):
+            writer.write(gradient(i)[:, :, ::-1])
+
+    assert probe(str(out)).has_audio is True
+
+
+def test_video_writer_ignores_silent_audio_source(tmp_path, video):
+    out = tmp_path / 'silent.mp4'
+    with VideoWriter(str(out), WIDTH, HEIGHT, 30, audio_from=video) as writer:
+        writer.write(gradient(0)[:, :, ::-1])
+
+    assert probe(str(out)).has_audio is False
+
+
+def test_video_writer_rejects_odd_dimensions(tmp_path):
+    out = tmp_path / 'odd.mp4'
+    with pytest.raises(VideoIOError) as excinfo:
+        VideoWriter(str(out), 65, HEIGHT, 30)
+    assert str(out) in str(excinfo.value)
+    assert not out.exists()
+
+
+def test_first_frame_returns_rgb_array(video):
+    frame = first_frame(video)
+    assert frame is not None
+    assert frame.shape == (HEIGHT, WIDTH, 3)
+    assert frame.dtype == np.uint8
+    # Red channel ramps left to right in the synthesized gradient.
+    assert int(frame[0, -1, 0]) > int(frame[0, 0, 0])
+
+
+def test_first_frame_returns_none_for_garbage(junk):
+    assert first_frame(junk) is None
+
+
+def test_first_frame_returns_none_for_missing_file(tmp_path):
+    assert first_frame(str(tmp_path / 'nope.mp4')) is None

--- a/tests/test_video_io.py
+++ b/tests/test_video_io.py
@@ -170,6 +170,19 @@ def test_video_writer_roundtrip(tmp_path):
     assert int(frames[0][0, -1, 2]) - int(frames[0][0, 0, 2]) > 200
 
 
+def test_video_writer_accepts_encoder_options(tmp_path):
+    out = tmp_path / 'preset.mp4'
+    with VideoWriter(str(out), WIDTH, HEIGHT, 30,
+                     options={'preset': 'veryfast'}) as writer:
+        for i in range(10):
+            writer.write(gradient(i)[:, :, ::-1])
+
+    info = probe(str(out))
+    assert (info.width, info.height) == (WIDTH, HEIGHT)
+    with VideoReader(str(out)) as reader:
+        assert len(list(reader.frames())) == 10
+
+
 def test_video_writer_copies_audio(tmp_path):
     source = make_video(tmp_path / 'source.mp4', with_audio=True)
     out = tmp_path / 'with_audio.mp4'

--- a/utils/dataset_preprocessing_utils.py
+++ b/utils/dataset_preprocessing_utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import queue
 from pathlib import Path
 
 import numpy as np
@@ -7,11 +8,14 @@ import cv2
 import PIL.Image
 import PIL.ImageOps
 import torchvision.transforms as transforms
-import ffmpeg
 
+from utils import video_io
 from utils.user_data import data_path
 
 logger = logging.getLogger(__name__)
+
+# Frames between progress messages, so the queue is not flooded.
+PROGRESS_INTERVAL = 10
 
 
 class DatasetPreprocessingUtils:
@@ -129,44 +133,12 @@ class DatasetPreprocessingUtils:
 
     @staticmethod
     def calculate_video_duration(video_path):
-        probe = ffmpeg.probe(video_path)
-        video_info = next(s for s in probe['streams'] if s['codec_type'] == 'video')
-
-        duration = None
-        
-        if 'duration' in video_info and video_info['duration']:
-            try:
-                duration = float(video_info['duration'])
-            except (ValueError, TypeError):
-                pass
-        
-        if duration is None and 'tags' in video_info:
-            tags = video_info['tags']
-            if 'DURATION' in tags:
-                try:
-                    time_str = tags['DURATION']
-                    parts = time_str.split(':')
-                    if len(parts) == 3:
-                        hours = float(parts[0])
-                        minutes = float(parts[1])
-                        seconds = float(parts[2])
-                        duration = hours * 3600 + minutes * 60 + seconds
-                except (ValueError, TypeError, IndexError):
-                    pass
-        
-        if duration is None and 'format' in probe:
-            format_info = probe['format']
-            if 'duration' in format_info and format_info['duration']:
-                try:
-                    duration = float(format_info['duration'])
-                except (ValueError, TypeError):
-                    pass
-        
-        if duration is None:
-            logger.warning("Could not determine duration for video %s, using default estimate", video_path)
-            duration = 0
-        
-        return duration
+        """Duration of a video in seconds, or 0 when it cannot be determined."""
+        try:
+            return video_io.probe(video_path).duration
+        except video_io.VideoIOError as e:
+            logger.warning("Could not determine duration for video %s: %s", video_path, e)
+            return 0
 
     @staticmethod
     def calculate_expected_video_frames(video_path, fps=10):
@@ -175,100 +147,73 @@ class DatasetPreprocessingUtils:
 
     @staticmethod
     def extract_videos(video_paths, fps, queue_in, queue_out):
-        if not queue_in.empty():
-            if queue_in.get() == "cancel":
-                return
-        
-        results = []
-        total_videos = len(video_paths)
+        """Extract JPEG frames from each video into a sibling directory.
 
-        expected_per_video = []
-        for video_path in video_paths:
-            try:
-                expected_per_video.append(
-                    DatasetPreprocessingUtils.calculate_expected_video_frames(video_path, fps)
-                )
-            except Exception as e:
-                logger.warning("Could not estimate frame count for %s: %s", video_path, e)
-                expected_per_video.append(0)
-        total_expected = sum(expected_per_video)
-        frames_done_prior = 0
+        Reports progress on ``queue_out`` as a fraction of the frame count
+        expected across all videos, and stops when ``queue_in`` says "cancel".
+        """
+        cancelled = False
+
+        def should_cancel():
+            nonlocal cancelled
+            while not cancelled and not queue_in.empty():
+                try:
+                    cancelled = queue_in.get_nowait() == "cancel"
+                except queue.Empty:
+                    break
+            return cancelled
+
+        if should_cancel():
+            return
+
+        total_videos = len(video_paths)
+        total_expected = sum(DatasetPreprocessingUtils.calculate_expected_video_frames(p, fps)
+                             for p in video_paths)
+        frames_done = 0
+        results = []
 
         for i, video_path in enumerate(video_paths):
-            if not queue_in.empty():
-                if queue_in.get() == "cancel":
-                    return
-
-            # Extract frames for this video
-            video_path_obj = Path(video_path)
-            video_dir = video_path_obj.parent
-            video_name = video_path_obj.stem
-            save_path = video_dir / f"{video_name}_frames @ {fps} fps"
-            save_path.mkdir(parents=True, exist_ok=True)
-
-            output_pattern = str(save_path / f"{video_name}_frame_%05d.jpg")
-
-            if total_expected > 0:
-                start_pct = min(frames_done_prior / total_expected * 100.0, 99.0)
-            else:
-                start_pct = (i / total_videos * 100.0) if total_videos > 0 else 0.0
-            queue_out.put({
-                'type': 'progress',
-                'current': i,
-                'total': total_videos,
-                'current_file': video_path_obj.name,
-                'percentage': start_pct,
-            })
-
-            process = (
-                ffmpeg
-                .input(video_path)
-                .output(output_pattern, vf=f"fps={fps}")
-                .global_args('-progress', 'pipe:1', '-nostats')
-                .run_async(pipe_stdout=True)
-            )
-
-            cancelled = False
-            while True:
-                line = process.stdout.readline()
-                if not line:
-                    break
-                line = line.decode('utf-8', errors='ignore').strip()
-                if line.startswith('frame='):
-                    try:
-                        cur_frame = int(line.split('=', 1)[1])
-                    except ValueError:
-                        cur_frame = 0
-                    if total_expected > 0:
-                        done = frames_done_prior + min(cur_frame, expected_per_video[i])
-                        pct = min(done / total_expected * 100.0, 99.0)
-                    else:
-                        pct = (i / total_videos * 100.0) if total_videos > 0 else 0.0
-                    queue_out.put({
-                        'type': 'progress',
-                        'current': i,
-                        'total': total_videos,
-                        'current_file': video_path_obj.name,
-                        'percentage': pct,
-                    })
-
-                if not queue_in.empty() and queue_in.get() == "cancel":
-                    process.terminate()
-                    cancelled = True
-                    break
-
-            if cancelled:
+            if should_cancel():
                 return
 
-            retcode = process.wait()
-            frames_done_prior += expected_per_video[i]
-            if retcode != 0:
-                logger.error("FFmpeg failed for %s (exit code %s)", video_path, retcode)
+            source = Path(video_path)
+            save_path = source.parent / f"{source.stem}_frames @ {fps} fps"
+
+            def report(done, index=i, name=source.name):
+                if total_expected > 0:
+                    percentage = min(done / total_expected * 100.0, 100.0)
+                else:
+                    percentage = (index / total_videos * 100.0) if total_videos > 0 else 0.0
+                queue_out.put({
+                    'type': 'progress',
+                    'current': index,
+                    'total': total_videos,
+                    'current_file': name,
+                    'percentage': percentage,
+                })
+
+            def on_progress(written_here, base=frames_done):
+                if written_here % PROGRESS_INTERVAL == 0:
+                    report(base + written_here)
+
+            report(frames_done)
+            try:
+                written = video_io.extract_frames(video_path, fps, str(save_path), source.stem,
+                                                  on_progress=on_progress,
+                                                  should_cancel=should_cancel)
+            except video_io.VideoIOError as e:
+                logger.error("Frame extraction failed for %s: %s", video_path, e)
                 continue
+
+            frames_done += written
+            if cancelled:
+                return
+            report(frames_done)
             results.append(str(save_path))
 
         queue_out.put({'type': 'completed', 'results': results})
-    
+
+
     @staticmethod
     def resize_image_np(image: np.ndarray, settings):
         target_size = settings.size

--- a/utils/video_io.py
+++ b/utils/video_io.py
@@ -1,0 +1,247 @@
+"""Video I/O built on PyAV: probing, frame extraction, reading and writing.
+
+This is the only module allowed to import ``av``; everything else in the
+codebase goes through the helpers here.
+"""
+import logging
+import os
+from dataclasses import dataclass
+from fractions import Fraction
+
+import av
+import cv2
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# Tolerance when comparing decoded timestamps against emission boundaries.
+_EPS = 1e-6
+
+
+class VideoIOError(Exception):
+    """A media file could not be opened, decoded or written."""
+
+
+@dataclass
+class MediaInfo:
+    duration: float
+    width: int
+    height: int
+    fps: float
+    has_audio: bool
+
+
+def _open(path, mode='r'):
+    try:
+        return av.open(str(path), mode=mode)
+    except (av.FFmpegError, OSError) as e:
+        raise VideoIOError(f'Cannot open "{path}": {e}') from e
+
+
+def _video_stream(container, path):
+    stream = next(iter(container.streams.video), None)
+    if stream is None:
+        raise VideoIOError(f'No video stream in "{path}"')
+    return stream
+
+
+def _media_info(container, stream, path):
+    if container.duration is not None:
+        duration = container.duration / av.time_base
+    elif stream.duration is not None and stream.time_base is not None:
+        duration = float(stream.duration * stream.time_base)
+    else:
+        logger.warning('Unknown duration for "%s"', path)
+        duration = 0.0
+    return MediaInfo(
+        duration=duration,
+        width=stream.width or 0,
+        height=stream.height or 0,
+        fps=float(stream.average_rate) if stream.average_rate else 0.0,
+        has_audio=bool(container.streams.audio),
+    )
+
+
+def probe(path):
+    """Container/stream metadata of a media file."""
+    with _open(path) as container:
+        return _media_info(container, _video_stream(container, path), path)
+
+
+def first_frame(path):
+    """First decodable frame as an rgb24 HxWx3 array, or None if unreadable."""
+    try:
+        with _open(path) as container:
+            for frame in container.decode(video=0):
+                return frame.to_ndarray(format='rgb24')
+        logger.warning('No decodable frame in "%s"', path)
+    except (VideoIOError, av.FFmpegError, OSError, ValueError, IndexError) as e:
+        logger.warning('Cannot read first frame of "%s": %s', path, e)
+    return None
+
+
+def extract_frames(path, fps, out_dir, name_prefix, on_progress=None, should_cancel=None):
+    """Write JPEG frames sampled at ``fps`` into ``out_dir``; return how many.
+
+    Files are named ``{name_prefix}_frame_{n:05d}.jpg`` with ``n`` starting at 1.
+    Emission is driven by decoded timestamps, so variable frame rate sources and
+    sources slower than the target rate still yield the expected frame count.
+    """
+    if fps <= 0:
+        raise VideoIOError(f'Invalid target fps {fps} for "{path}"')
+    os.makedirs(out_dir, exist_ok=True)
+
+    written = 0
+    with _open(path) as container:
+        stream = _video_stream(container, path)
+        stream.thread_type = 'AUTO'
+        source_rate = float(stream.average_rate) if stream.average_rate else 0.0
+        step = 1.0 / source_rate if source_rate else 1.0 / fps
+
+        def emit(image):
+            nonlocal written
+            written += 1
+            cv2.imwrite(os.path.join(out_dir, f'{name_prefix}_frame_{written:05d}.jpg'),
+                        image, [cv2.IMWRITE_JPEG_QUALITY, 90])
+            if on_progress is not None:
+                on_progress(written)
+
+        cancelled = False
+        last_image = None
+        end_time = 0.0
+        try:
+            for index, frame in enumerate(container.decode(stream)):
+                if should_cancel is not None and should_cancel():
+                    cancelled = True
+                    break
+                if frame.pts is not None and stream.time_base is not None:
+                    timestamp = float(frame.pts * stream.time_base)
+                elif source_rate:
+                    timestamp = index / source_rate
+                else:
+                    timestamp = written / fps
+                duration = (float(frame.duration * stream.time_base)
+                            if frame.duration and stream.time_base is not None else step)
+                end_time = timestamp + duration
+                if timestamp + _EPS < written / fps:
+                    continue
+                last_image = frame.to_ndarray(format='bgr24')
+                while timestamp + _EPS >= written / fps:
+                    emit(last_image)
+        except av.FFmpegError as e:
+            raise VideoIOError(f'Failed to decode "{path}": {e}') from e
+
+        # The last frame stays on screen for its own duration; holding it there
+        # keeps the count matching the ffmpeg fps filter on slow sources.
+        if not cancelled and last_image is not None:
+            while written / fps < end_time - _EPS:
+                emit(last_image)
+    return written
+
+
+class VideoReader:
+    """Sequential decoder yielding bgr24 frames; usable as a context manager."""
+
+    def __init__(self, path):
+        self.path = str(path)
+        self._container = _open(self.path)
+        try:
+            self._stream = _video_stream(self._container, self.path)
+            self._stream.thread_type = 'AUTO'
+            self.info = _media_info(self._container, self._stream, self.path)
+        except VideoIOError:
+            self._container.close()
+            raise
+
+    def frames(self):
+        try:
+            for frame in self._container.decode(self._stream):
+                yield frame.to_ndarray(format='bgr24')
+        except av.FFmpegError as e:
+            raise VideoIOError(f'Failed to decode "{self.path}": {e}') from e
+
+    def close(self):
+        if self._container is not None:
+            self._container.close()
+            self._container = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+
+class VideoWriter:
+    """H.264/yuv420p mp4 encoder; usable as a context manager.
+
+    ``audio_from`` names a source file whose audio stream, if any, is remuxed
+    by packet copy. ``bit_rate`` is in bits per second.
+    """
+
+    def __init__(self, path, width, height, fps, audio_from=None, bit_rate=None):
+        self.path = str(path)
+        if width % 2 or height % 2:
+            raise VideoIOError(
+                f'Odd frame size {width}x{height} for "{self.path}"; '
+                'yuv420p requires even width and height')
+        self._container = _open(self.path, mode='w')
+        try:
+            self._stream = self._container.add_stream(
+                'libx264', rate=Fraction(fps).limit_denominator(65535))
+            self._stream.width = width
+            self._stream.height = height
+            self._stream.pix_fmt = 'yuv420p'
+            if bit_rate:
+                self._stream.bit_rate = bit_rate
+            if audio_from is not None:
+                self._copy_audio(audio_from)
+        except av.FFmpegError as e:
+            self._container.close()
+            self._container = None
+            raise VideoIOError(f'Cannot set up "{self.path}": {e}') from e
+        except Exception:
+            self._container.close()
+            self._container = None
+            raise
+
+    def _copy_audio(self, source):
+        # The audio stream must exist before the first video packet is muxed.
+        # Muxing all audio up front keeps the writer simple; the muxer holds the
+        # compressed audio (small) until video timestamps catch up.
+        with _open(source) as container:
+            stream = next(iter(container.streams.audio), None)
+            if stream is None:
+                return
+            out_stream = self._container.add_stream_from_template(stream)
+            for packet in container.demux(stream):
+                if packet.dts is None:
+                    continue
+                packet.stream = out_stream
+                self._container.mux(packet)
+
+    def write(self, frame_bgr):
+        frame = av.VideoFrame.from_ndarray(np.ascontiguousarray(frame_bgr), format='bgr24')
+        try:
+            for packet in self._stream.encode(frame):
+                self._container.mux(packet)
+        except av.FFmpegError as e:
+            raise VideoIOError(f'Failed to encode "{self.path}": {e}') from e
+
+    def close(self):
+        if self._container is None:
+            return
+        try:
+            for packet in self._stream.encode():
+                self._container.mux(packet)
+        except av.FFmpegError as e:
+            raise VideoIOError(f'Failed to finalize "{self.path}": {e}') from e
+        finally:
+            self._container.close()
+            self._container = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()

--- a/utils/video_io.py
+++ b/utils/video_io.py
@@ -176,10 +176,12 @@ class VideoWriter:
     """H.264/yuv420p mp4 encoder; usable as a context manager.
 
     ``audio_from`` names a source file whose audio stream, if any, is remuxed
-    by packet copy. ``bit_rate`` is in bits per second.
+    by packet copy. ``bit_rate`` is in bits per second. ``options`` are passed
+    to the libx264 encoder (e.g. {'preset': 'veryfast'}).
     """
 
-    def __init__(self, path, width, height, fps, audio_from=None, bit_rate=None):
+    def __init__(self, path, width, height, fps, audio_from=None, bit_rate=None,
+                 options=None):
         self.path = str(path)
         if width % 2 or height % 2:
             raise VideoIOError(
@@ -188,7 +190,8 @@ class VideoWriter:
         self._container = _open(self.path, mode='w')
         try:
             self._stream = self._container.add_stream(
-                'libx264', rate=Fraction(fps).limit_denominator(65535))
+                'libx264', rate=Fraction(fps).limit_denominator(65535),
+                options=options or {})
             self._stream.width = width
             self._stream.height = height
             self._stream.pix_fmt = 'yuv420p'

--- a/uv.lock
+++ b/uv.lock
@@ -65,15 +65,12 @@ name = "autolume"
 version = "2.18.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "av" },
     { name = "click" },
     { name = "codecarbon" },
     { name = "fbpca" },
-    { name = "ffmpeg-downloader" },
-    { name = "ffmpeg-python" },
     { name = "filedialpy" },
     { name = "glfw" },
-    { name = "imageio" },
-    { name = "imageio-ffmpeg" },
     { name = "imgui" },
     { name = "kmeans-pytorch" },
     { name = "kornia" },
@@ -115,15 +112,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "av", specifier = ">=18.1,<19" },
     { name = "click", specifier = ">=8.1.8" },
     { name = "codecarbon", specifier = ">=3.2.6" },
     { name = "fbpca", specifier = "==1.0" },
-    { name = "ffmpeg-downloader", specifier = ">=0.5.2" },
-    { name = "ffmpeg-python", specifier = "==0.2.0" },
     { name = "filedialpy", git = "https://github.com/ucodia/filedialpy.git?tag=v1.3.4-fixes" },
     { name = "glfw", specifier = ">=2.8.0" },
-    { name = "imageio", specifier = "==2.31.5" },
-    { name = "imageio-ffmpeg", specifier = "==0.4.9" },
     { name = "imgui", specifier = "==1.4.1" },
     { name = "kmeans-pytorch", specifier = "==0.3" },
     { name = "kornia", specifier = "==0.7.0" },
@@ -160,6 +154,23 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=9.1.1" }]
+
+[[package]]
+name = "av"
+version = "18.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/f4/f22114d30d3435e38c6af2b4870f37b864403dca6ae7af747a289ce0a18e/av-18.1.0.tar.gz", hash = "sha256:47bfc286e1bc9de7ab4681fc2b575cd2460a66919d31ffe1bd5aa54fae531a28", size = 4451061, upload-time = "2026-08-12T22:28:18.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/d4/d7cdc8bff143c17a6d35924375ae28dd692cacde38700a7d419fde54f44a/av-18.1.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:ae75d8bb6467895ed1f8572ededf7ffa49eac07f6e483222f5d7d62a41d12f04", size = 22546147, upload-time = "2026-08-12T22:27:11.851Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c9/37a619297492256b77d5ed906e7d8166c10a26ed251dccf1ae03ab19bff6/av-18.1.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:b30a4e8d934558e19602b68998a4d9ac9f250fa0dacef216f7e8e40153b13316", size = 18217603, upload-time = "2026-08-12T22:27:14.713Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/84/2464ffb64c08c5ce8b522c8e74594714414e3b0575267652c5c51c0574b9/av-18.1.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6fc837cc51adf80331ac850779cd53b5d4c4460b0ebe9057a02a921c6736f19d", size = 33640142, upload-time = "2026-08-12T22:27:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/204dbfc3e08eb4cdc6e6ff57be02150bc44523ebdb50182d10025792ebd9/av-18.1.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:8a032e8d8ebc73dec079364b9b4a6837638a2d106e8472314e685ffbf163e700", size = 35786210, upload-time = "2026-08-12T22:27:20.984Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/99/b0d04ec553ff9a7e00455458dfa3a39c8a8f627b273056b4e5fe57d590de/av-18.1.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:3c8b1f8b46f99d52e2d8b0ed5d0cdadf172d24794d46e2077b16e44ed08e26ff", size = 39379798, upload-time = "2026-08-12T22:27:24.432Z" },
+    { url = "https://files.pythonhosted.org/packages/56/b1/e00d4feae59160149df6126585e726fdc6300798fd40c5dd324879e81f68/av-18.1.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ab5ac081bc9eaf54109120d4e56284674fecfbe520d9aa1707c7fa911ec5f4d2", size = 34690321, upload-time = "2026-08-12T22:27:27.769Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/94/836fa987e3084d11a21489f11357fb24843ef3aa8faf74ddddfc603d5062/av-18.1.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:191224788d87af06c31784a395bb73f14b72f33d7f4871ace0157de2abdc6276", size = 36859932, upload-time = "2026-08-12T22:27:31.403Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b4/76ba21e46704f632004276b85289a1582e95f5eff760436d6149875a1881/av-18.1.0-cp311-abi3-win_amd64.whl", hash = "sha256:ea1480b7a8d5405cb5f382b344731bf125fd2c1c6fae3964f6c48595628387ff", size = 27595679, upload-time = "2026-08-12T22:27:35.177Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ad/a3135884c5753b09773176b97201ae602f67ad14206c395ff838d66bf9b0/av-18.1.0-cp311-abi3-win_arm64.whl", hash = "sha256:5509ec12aaa19fd6601de13cfa6f4cdad450da07982118510592875d970454d6", size = 20257584, upload-time = "2026-08-12T22:27:38.472Z" },
+]
 
 [[package]]
 name = "certifi"
@@ -350,35 +361,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/2085d0645a4bb4f0b606251b0b7466c61326e4a471d445c1c3761a2d07bc/fbpca-1.0.tar.gz", hash = "sha256:150677642479663f317fdbb5e06dab3f98721cf7031bb4a84113d7a631c472d1", size = 11758, upload-time = "2014-12-09T21:25:39.221Z" }
 
 [[package]]
-name = "ffmpeg-downloader"
-version = "0.5.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "platformdirs" },
-    { name = "requests" },
-    { name = "tabulate" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/79/42/71b4291e8b6ad58e0e9953d9ad7384f5e2d05191ba07e610223ddd47c022/ffmpeg_downloader-0.5.2.tar.gz", hash = "sha256:ba616a66f159715234e5215b8c1f50d1f021d5d5b7dcb467feaf385df3c091e9", size = 39641, upload-time = "2026-06-04T02:03:29.309Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/64/561a1c9ed1d0835e9e1d8d0cc40e260b9d411b6007b5fa41f8288fd4d0f2/ffmpeg_downloader-0.5.2-py3-none-any.whl", hash = "sha256:deb8167ae1696bd4c6f5644d3a6a7ee1972cb5b5cc98a1032857562cf4d42ca0", size = 49142, upload-time = "2026-06-04T02:03:27.975Z" },
-]
-
-[[package]]
-name = "ffmpeg-python"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "future" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/5e/d5f9105d59c1325759d838af4e973695081fbbc97182baf73afc78dec266/ffmpeg-python-0.2.0.tar.gz", hash = "sha256:65225db34627c578ef0e11c8b1eb528bb35e024752f6f10b78c011f6f64c4127", size = 21543, upload-time = "2019-07-06T00:19:08.989Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl", hash = "sha256:ac441a0404e053f8b6a1113a77c0f452f1cfc62f6344a769475ffdc0f56c23c5", size = 25024, upload-time = "2019-07-06T00:19:07.215Z" },
-]
-
-[[package]]
 name = "filedialpy"
 version = "1.3.4"
 source = { git = "https://github.com/ucodia/filedialpy.git?tag=v1.3.4-fixes#d4dd80e59ac508c2ca3f07c69c98a0572c8a8767" }
@@ -434,15 +416,6 @@ wheels = [
 ]
 
 [[package]]
-name = "future"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a7/b2/4140c69c6a66432916b26158687e821ba631a4c9273c474343badf84d3ba/future-1.0.0.tar.gz", hash = "sha256:bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05", size = 1228490, upload-time = "2024-02-21T11:52:38.461Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/71/ae30dadffc90b9006d77af76b393cb9dfbfc9629f339fc1574a1c52e6806/future-1.0.0-py3-none-any.whl", hash = "sha256:929292d34f5872e70396626ef385ec22355a1fae8ad29e1a734c3e43f9fbc216", size = 491326, upload-time = "2024-02-21T11:52:35.956Z" },
-]
-
-[[package]]
 name = "glfw"
 version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -494,22 +467,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ca/b5/ad9fe89e2fd601c321e22e12be73aa07d95220d309a2936dc09677460062/imageio-2.31.5.tar.gz", hash = "sha256:d8e53f9cd4054880276a3dac0a28c85ba7874084856a55a0294a8ae6ed7f3a8e", size = 387057, upload-time = "2023-10-02T02:15:23.277Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/37/e21e6f38b93878ba80302e95b8ccd4718d80f0c53055ccae343e606b1e2d/imageio-2.31.5-py3-none-any.whl", hash = "sha256:97f68e12ba676f2f4b541684ed81f7f3370dc347e8321bc68ee34d37b2dbac9f", size = 313180, upload-time = "2023-10-02T02:15:21.32Z" },
-]
-
-[[package]]
-name = "imageio-ffmpeg"
-version = "0.4.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/28/c6/7f9990d8f9378bb4b8c60c08c2a1f565c44d9445c1f01fbbd5bed21379d9/imageio-ffmpeg-0.4.9.tar.gz", hash = "sha256:39bcd1660118ef360fa4047456501071364661aa9d9021d3d26c58f1ee2081f5", size = 17378, upload-time = "2023-09-12T10:02:39.256Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/95/9470ac4c10eb4265ba6eef2717b4758daec3ca0d5877eb40e9a5a3933bac/imageio_ffmpeg-0.4.9-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:24095e882a126a0d217197b86265f821b4bb3cf9004104f67c1384a2b4b49168", size = 22532573, upload-time = "2023-09-12T10:02:10.069Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/98/3df1d8dd8f2c121b6c588b1e0d604f36592d56df9c41fb155ed546c6a5ed/imageio_ffmpeg-0.4.9-py3-none-manylinux2010_x86_64.whl", hash = "sha256:2996c64af3e5489227096580269317719ea1a8121d207f2e28d6c24ebc4a253e", size = 26900041, upload-time = "2023-09-12T10:02:36.851Z" },
-    { url = "https://files.pythonhosted.org/packages/95/ed/f39ca78db7230175a99a22799af2d589105227f5f5f52b65160492c6573f/imageio_ffmpeg-0.4.9-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7eead662d2f46d748c0ab446b68f423eb63d2b54d0a8ef96f80607245540866d", size = 22880108, upload-time = "2023-09-12T10:02:17.01Z" },
-    { url = "https://files.pythonhosted.org/packages/30/6f/413aac226d2d08d6fa40e712dd2fe7a9f362b9231852a57a3bf8c8e78015/imageio_ffmpeg-0.4.9-py3-none-win32.whl", hash = "sha256:b6de1e18911687c538d5585d8287ab1a23624ca9dc2044fcc4607de667bcf11e", size = 19651749, upload-time = "2023-09-12T10:02:29.908Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/01/716106099e48c4f419876d5814679a94dd7d6f441217c97c1b608123c6bb/imageio_ffmpeg-0.4.9-py3-none-win_amd64.whl", hash = "sha256:7e900c695c6541b1cb17feb1baacd4009b30a53a45b81c23d53a67ab13ffb766", size = 22619540, upload-time = "2023-09-12T10:02:23.577Z" },
 ]
 
 [[package]]
@@ -1032,15 +989,6 @@ wheels = [
 ]
 
 [[package]]
-name = "platformdirs"
-version = "4.9.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
-]
-
-[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1517,15 +1465,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
-]
-
-[[package]]
-name = "tabulate"
-version = "0.10.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
 ]
 
 [[package]]

--- a/widgets/thumbnail_widget.py
+++ b/widgets/thumbnail_widget.py
@@ -12,6 +12,7 @@ import imgui
 import PIL.Image
 import PIL.ImageOps
 
+from utils import video_io
 from utils.gui_utils import gl_utils
 
 logger = logging.getLogger(__name__)
@@ -42,16 +43,7 @@ def _render_thumbnail(file_path, size, padding):
     video_ext = ('.mp4', '.avi', '.mov', '.mkv', '.wmv', '.flv', '.webm')
     try:
         if file_path.lower().endswith(video_ext):
-            cap = cv2.VideoCapture(file_path)
-            ok, frame = (cap.read() if cap.isOpened() else (False, None))
-            cap.release()
-            if not ok:
-                return None
-            if frame.ndim == 3 and frame.shape[2] == 3:
-                frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-            elif frame.ndim == 3 and frame.shape[2] == 4:
-                frame = cv2.cvtColor(frame, cv2.COLOR_BGRA2RGBA)
-            img = frame
+            img = video_io.first_frame(file_path)
         else:
             # Decode JPEGs at reduced resolution: draft() lets libjpeg downsample
             # while decoding (e.g. a 4K source straight to ~1/8 size), a big win


### PR DESCRIPTION
## Summary

Replaces all three of Autolume's FFmpeg channels — ffmpeg/ffprobe CLI subprocesses (via the unmaintained ffmpeg-python), the imageio writer, and cv2 video decoding/encoding — with in-process PyAV (`av` 18.1.0, bundling FFmpeg 8.1.2, the same version we shipped as exes). All video I/O now goes through one new module, `utils/video_io.py` (`probe`, `first_frame`, `extract_frames`, `VideoReader`, `VideoWriter` with audio remux and encoder options); no other module imports `av`, and no video path bypasses it — including the perform-module recorder, which now encodes real H.264 instead of mp4v.

This structurally eliminates the frozen-build subprocess pathologies: probing is 1–4 ms in-process instead of a 97 MB `ffprobe.exe` spawn (fixes #62), and no console windows can ever appear from the windowed app. Extraction gains exact per-frame progress and Python-level cancellation; the import popup probes durations on worker threads and the expected-frames caching is gone. Packaging drops the bundled exes, `ffmpeg-downloader`, `ffmpeg-python`, `imageio-ffmpeg`, and the direct `imageio` pin (kept transitively by scikit-image) — net Windows release size ≈ **−128 MB** — and dev setup no longer requires a system FFmpeg on any platform. Also fixes a latent super-res bug (custom-size output height was taken from `out_width`).

Supersedes #65, which patched the same #62 symptoms on top of the subprocess architecture.

## Related issue

Closes #62

## Type of change

- [ ] Feature
- [ ] Fix
- [x] Other (docs, refactor, chore, ci, etc.)

## How was this tested?

- `uv run pytest -q` — **200 passed** (29 new tests: `test_video_io.py` ×18 with fixtures synthesized by `av` itself — no checked-in media, CI-safe; `test_preprocessing_video.py` ×9; `test_thumbnail_widget.py` ×2). Channel order (BGR/RGB) is pinned in both the reader and the writer roundtrip; audio remux asserts full duration, not just stream presence.
- End-to-end headless, real files: all six supported formats (mp4/avi/mov/mkv/webm/gif) probed correctly (including webm's tag-only duration) and ran through `extract_videos` — exactly 280 frames at 10 FPS in 1.5 s, monotonic progress ending at 100%, identical output dir/file naming (`<stem>_frames @ N fps/<stem>_frame_00001.jpg`).
- Extraction frame-count parity vs the old ffmpeg CLI verified on 7 synthetic cases: 6 exact matches; edge case where the source tail partially covers a boundary can emit one extra frame (never fewer) — pts-based boundary rule, documented in the module.
- Audio remux verified: `VideoWriter(audio_from=...)` copies AAC packets without re-encoding; output probes with both streams and correct duration.
- Multi-agent implementation with an independent verification pass: API-contract conformance at every call site, GUI↔worker queue protocol read on both sides, render-thread audit (no media I/O on the GUI thread anywhere), leftover-reference scan (zero hits for `import ffmpeg`, `ffprobe`, `run_async`, `IMAGEIO_FFMPEG`, `import imageio`, `cv2.VideoCapture`, `cv2.VideoWriter`).
- **Needs human verification**: full GUI flow on a rebuilt release (import all formats → popup instant, count fills in → extract → thumbnails), super-res on a real video with audio, projection recording, **performance recording in the perform module** (last commit moved it from cv2/mp4v to `video_io`/H.264 — untestable headlessly; check the recording plays and stop latency is acceptable), and one real PyInstaller build (the `hook-av` collection was verified present but not exercised by an actual build).

Behavior notes worth a release-note line:
- `VideoWriter` rejects odd width/height with a clear error where ffmpeg previously failed silently on stderr; the perform recorder crops a stray odd row/column instead.
- Performance recordings are now real H.264 (previously mp4v mislabeled as H.264 in a comment); a failed recording encode logs an error instead of dying silently on its thread.

## Checklist

- [x] PR title follows Conventional Commits without a scope (`<type>: <subject>`)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Documentation in `docs/` or `README.md` is updated if user-visible behavior changed (README/AGENTS/CONTRIBUTING FFmpeg install steps removed)
- [x] If this PR adds new runtime files, they are included in `release.py` (no new runtime files; `av` is collected by the standard PyInstaller hook, and the exe bundling code is removed)
- [ ] Screenshots or a short clip are attached for UI changes (needs a human at the desktop; only the "(calculating...)" suffix is visually new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)