### PR TITLE
fix: use cmd instead of ctrl for shortcuts on macos

### DIFF
--- a/utils/gui_utils/imgui_window.py
+++ b/utils/gui_utils/imgui_window.py
@@ -44,6 +44,9 @@ class ImguiWindow(glfw_window.GlfwWindow):
         self._attach_glfw_callbacks()
         imgui.get_io().ini_saving_rate = 0 # Disable creating imgui.ini at runtime.
         imgui.get_io().mouse_drag_threshold = 0 # Improve behavior with imgui_utils.drag_custom().
+        if sys.platform == 'darwin':
+            # Cmd instead of Ctrl for text editing shortcuts (Cmd+A/C/V/X/Z).
+            imgui.get_io().config_mac_osx_behaviors = True
         self._font_path  = font
         self._font_sizes = font_sizes
         self._pending_font_sizes = None

--- a/widgets/thumbnail_widget.py
+++ b/widgets/thumbnail_widget.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 import math
 import collections
 import queue
@@ -243,13 +244,18 @@ class ThumbnailWidget:
                               (height - imgui.get_text_line_height()) / 2))
         imgui.text_colored(message, 0.5, 0.5, 0.5, 1.0)
 
+    def _shortcut_mod_down(self):
+        # Cmd on macOS, Ctrl elsewhere.
+        io = imgui.get_io()
+        return io.key_super if sys.platform == 'darwin' else io.key_ctrl
+
     def _select(self, idx):
-        ctrl = imgui.is_key_down(341) or imgui.is_key_down(345)
+        mod = self._shortcut_mod_down()
         shift = imgui.is_key_down(340) or imgui.is_key_down(344)
         if shift and self.last_selected_idx is not None:
             lo, hi = sorted((self.last_selected_idx, idx))
             self.selected_indices = list(range(lo, hi + 1))
-        elif ctrl:
+        elif mod:
             if idx in self.selected_indices:
                 self.selected_indices.remove(idx)
             else:
@@ -260,8 +266,7 @@ class ThumbnailWidget:
             self.last_selected_idx = idx
 
     def _handle_shortcuts(self):
-        ctrl = imgui.is_key_down(341) or imgui.is_key_down(345)
-        if ctrl and imgui.is_key_pressed(65):                       # Ctrl+A
+        if self._shortcut_mod_down() and imgui.is_key_pressed(65):  # Cmd/Ctrl+A
             self.select_all()
         if imgui.is_key_pressed(261) or imgui.is_key_pressed(259):  # Delete / Backspace
             if self.selected_indices or self.last_selected_idx is not None:


### PR DESCRIPTION
## Summary

On macOS, all shortcuts expected the Windows/Linux Ctrl modifier instead of Cmd. This enables Dear ImGui's `config_mac_osx_behaviors` flag on darwin so text fields use Cmd+A/C/V/X/Z (plus the bundled macOS text conventions: Alt+arrow word jump, Cmd+arrow line start/end, double-click word select), and makes the thumbnail grid's select-all and click-to-toggle multi-select use Cmd on macOS via imgui io state instead of hardcoded GLFW Ctrl keycodes.

## Related issue

Closes #67

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Other (docs, refactor, chore, ci, etc.)

## How was this tested?

- `uv run pytest`: 200 passed.
- Verified the pinned `imgui==1.4.1` exposes the `config_mac_osx_behaviors` setter and that its GLFW backend feeds `io.key_super` from the Cmd key, which `ImguiWindow._glfw_key_callback` forwards.
- Windows/Linux paths are unchanged: the flag is darwin-gated and the thumbnail modifier falls through to `io.key_ctrl`.
- Needs manual verification on macOS: Cmd+A/C/V/X in a text field; Cmd+A, Cmd-click toggle, and Shift-click range select in the dataset thumbnail grid.

## Checklist

- [x] PR title follows Conventional Commits without a scope (`<type>: <subject>`)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Documentation in `docs/` or `README.md` is updated if user-visible behavior changed (no doc mentions shortcut modifiers)
- [x] If this PR adds new runtime files, they are included in `release.py` (no new runtime files)
- [ ] Screenshots or a short clip are attached for UI changes (keyboard behavior, not visual)

Generated with AI assistance
